### PR TITLE
Updating "stale pod" reference

### DIFF
--- a/container-engine/gettingstartedwithsaladcloud.mdx
+++ b/container-engine/gettingstartedwithsaladcloud.mdx
@@ -113,7 +113,7 @@ GPUs and other frequently asked questions.
   - Salad bills per use at the org level. You can view your current bill at the org level.
   - You are billed per-second only for container instances in the “running” state. Instances in other states such as
     “downloading” and “allocating” are not billed.
-  - Bandwidth is not metered, and there are no "stale pod charges" for containers that are not running.
+  - Bandwidth is not metered, and there are no "stale charges" related to storage for containers that are not running.
 - **What about compliance on Salad?**
   - We are SOC 2 Type 1 compliant. You can read more about our compliance
     [here](https://blog.salad.com/salad-soc-2-certification/).


### PR DESCRIPTION
In reference to @seniorquico's comment on #55: https://github.com/SaladTechnologies/salad-cloud-docs/pull/55#discussion_r1771621600

Adjusting the reference of stale pod to be consistent with Salad's terminology of containers.
