### PR TITLE
Add support plan details

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@
 This repository contains the Markdown files and media assets for the SaladCloud product documentation hosted on
 ([docs.salad.com](https://docs.salad.com)).
 
+## Contributing
+
+We welcome contributions to the SaladCloud documentation. Please see the
+[contributing guidelines](./.github/CONTRIBUTING.md) for more information.
+
+## Running Locally
+
+You can preview changes by running the SaladCloud documentation locally. To get started:
+
+1. Install [Node.js](https://nodejs.org/en/) on your machine.
+2. Clone this repository to your machine.
+3. Run `npx mintlify dev` from the root directory of the cloned repository.
+
 ## Licenses
 
 The SaladCloud product documentation's Markdown files and supporting media assets in this repository are © 2024 by
@@ -15,15 +28,3 @@ The Salad Technologies name, the SaladCloud name, and the Salad logo design are 
 No adaptation or use of any kind of any of our trademarks or copyrights is allowed without the express written
 permission of Salad Technologies, Inc. For more information regarding the authorized uses of these items, please
 [contact us](mailto:cloud@salad.com).
-
-## Run it locally
-
-To run the documentation locally, you need to have [Node.js](https://nodejs.org/en/) installed on your machine.
-
-1. Clone the repository
-2. Run `npx mintlify dev` in the root directory
-
-## Contributing
-
-We welcome contributions to the SaladCloud documentation. Please see the
-[contributing guidelines](./.github/CONTRIBUTING.md) for more information.

--- a/mint.json
+++ b/mint.json
@@ -325,6 +325,10 @@
           "pages": ["guides/transcription/youtube"]
         }
       ]
+    },
+    {
+      "group": "SaladCloud Support",
+      "pages": ["support/status", "support/sales", "support/contact", "support/abuse"]
     }
   ],
   "topbarLinks": [
@@ -338,7 +342,7 @@
     },
     {
       "name": "Support",
-      "url": "/support"
+      "url": "support"
     }
   ],
   "topbarCtaButton": {

--- a/support.mdx
+++ b/support.mdx
@@ -1,21 +1,21 @@
 ---
-title: Support
+title: SaladCloud Support
 description: Need support for your SaladCloud account? Start here.
+mode: wide
 ---
 
-<Card title="Status Page" icon="traffic-light" href="https://cloud-status.salad.com">
-  Check the current status of the SaladCloud products and services. You may also subscribe to receive real-time
-  notifications when incidents occur.
-</Card>
-
-<Card title="Contact Sales" icon="seedling" href="mailto:cloud@salad.com">
-  Contact the SaladCloud Sales team with questions about pricing and for help with large deployments.
-</Card>
-
-<Card title="Contact Support" icon="comment" href="/support/contact">
-  Contact the SaladCloud Support team for general help with your SaladCloud account.
-</Card>
-
-<Card title="Report Abuse" icon="bug" href="mailto:dev@salad.com">
-  If you suspect abuse, please let us know.
-</Card>
+<CardGroup cols={2}>
+  <Card title="Status Page" icon="traffic-light" href="https://cloud-status.salad.com">
+    Check the current status of the SaladCloud products and services. You may also subscribe to receive real-time
+    notifications when incidents occur.
+  </Card>
+  <Card title="Contact Sales" icon="seedling" href="mailto:cloud@salad.com">
+    Contact the SaladCloud Sales team with questions about pricing and for help with large deployments.
+  </Card>
+  <Card title="Contact Support" icon="comment" href="/support/contact">
+    Contact the SaladCloud Support team for general help with your SaladCloud account.
+  </Card>
+  <Card title="Report Abuse" icon="bug" href="mailto:dev@salad.com">
+    If you suspect abuse, please let us know.
+  </Card>
+</CardGroup>

--- a/support/abuse.mdx
+++ b/support/abuse.mdx
@@ -1,0 +1,5 @@
+---
+title: Report Abuse
+icon: bug
+url: mailto:dev@salad.com
+---

--- a/support/contact.mdx
+++ b/support/contact.mdx
@@ -1,5 +1,6 @@
 ---
 title: Contact Support
+icon: comment
 ---
 
 SaladCloud Support is normally available Monday through Friday from 9am to 5pm Pacific Time. We respond to requests
@@ -9,7 +10,9 @@ based on the level of your support plan and the order your message was received.
 
 Your SaladCloud account automatically includes our basic support plan. This allows you to open an unlimited number of
 support tickets with prioritized help for account login, billing, and security issues. We can also provide general
-guidance on SaladCloud products and services.
+guidance on SaladCloud products and services. We will initially respond to basic support tickets for account login,
+billing, and security issues within one business day. Otherwise, we will initially respond to all other support tickets
+within two business days.
 
 <Tip>Need additional support? Contact us to learn more about our range of support plans.</Tip>
 

--- a/support/sales.mdx
+++ b/support/sales.mdx
@@ -1,0 +1,5 @@
+---
+title: Contact Sales
+icon: seedling
+url: mailto:cloud@salad.com
+---

--- a/support/status.mdx
+++ b/support/status.mdx
@@ -1,0 +1,5 @@
+---
+title: Status Page
+icon: traffic-light
+url: https://cloud-status.salad.com
+---


### PR DESCRIPTION
This adds additional details on our support plan response times, incorporates the support links in the sidebar navigation, and reorders the README... sharing the "getting started" bits before the _boring_ license details. 😅