### PR TITLE
Remove support navigation

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -325,10 +325,6 @@
           "pages": ["guides/transcription/youtube"]
         }
       ]
-    },
-    {
-      "group": "SaladCloud Support",
-      "pages": ["support/status", "support/sales", "support/contact", "support/abuse"]
     }
   ],
   "topbarLinks": [
@@ -342,7 +338,7 @@
     },
     {
       "name": "Support",
-      "url": "support"
+      "url": "/support"
     }
   ],
   "topbarCtaButton": {

--- a/support/abuse.mdx
+++ b/support/abuse.mdx
@@ -1,5 +1,0 @@
----
-title: Report Abuse
-icon: bug
-url: mailto:dev@salad.com
----

--- a/support/sales.mdx
+++ b/support/sales.mdx
@@ -1,5 +1,0 @@
----
-title: Contact Sales
-icon: seedling
-url: mailto:cloud@salad.com
----

--- a/support/status.mdx
+++ b/support/status.mdx
@@ -1,5 +1,0 @@
----
-title: Status Page
-icon: traffic-light
-url: https://cloud-status.salad.com
----


### PR DESCRIPTION
This reverts a portion of #66- the new, custom sidebar navigation for the support pages. It all looked fine and worked as expected locally... but after deploying to the production site, we get two "Product" navigation tabs. 🤔

![image](https://github.com/user-attachments/assets/b161fd19-e41b-41a9-b2af-85eae094ef71)
