### PR TITLE
validate all schemas in the specs folder

### DIFF
--- a/.github/scripts/validate-all-workflows.sh
+++ b/.github/scripts/validate-all-workflows.sh
@@ -1,4 +1,5 @@
 #! /usr/bin/bash
+set -e
 
 api_spec_dir="api-specs"
 

--- a/.github/scripts/validate-all-workflows.sh
+++ b/.github/scripts/validate-all-workflows.sh
@@ -3,7 +3,7 @@
 api_spec_dir="api-specs"
 
 # Spec can be in json or yaml
-for spec in $(find $api_spec_dir -type f -name "*.json" -o -name "*.yaml"); do
+for spec in $(find $api_spec_dir -type f -name "*.json" -o -name "*.yaml" -o -name "*.yml"); do
   echo "Validating $spec"
   npx --yes @apidevtools/swagger-cli validate $spec
 done

--- a/.github/scripts/validate-all-workflows.sh
+++ b/.github/scripts/validate-all-workflows.sh
@@ -1,0 +1,9 @@
+#! /usr/bin/bash
+
+api_spec_dir="api-specs"
+
+# Spec can be in json or yaml
+for spec in $(find $api_spec_dir -type f -name "*.json" -o -name "*.yaml"); do
+  echo "Validating $spec"
+  npx --yes @apidevtools/swagger-cli validate $spec
+done

--- a/.github/workflows/openapi-validate.yml
+++ b/.github/workflows/openapi-validate.yml
@@ -10,7 +10,5 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Run @apidevtools/swagger-cli validate on salad-cloud.yaml
-        run: npx @apidevtools/swagger-cli validate ./api-specs/salad-cloud.yaml
-      - name: Run @apidevtools/swagger-cli validate on salad-cloud-imds.json
-        run: npx @apidevtools/swagger-cli validate ./api-specs/salad-cloud-imds.json
+      - name: Validate All API Specs
+        run: .github/scripts/validate-all-workflows.sh


### PR DESCRIPTION
Since there are many (and growing) API specs now, I changed the validator check to check any json or yaml file in the api specs repo. this way we don't have to maintain a growing list in the action.