### PR TITLE
hopefully clarify some peculiarities

### DIFF
--- a/products/sce/container-groups/container-logs.mdx
+++ b/products/sce/container-groups/container-logs.mdx
@@ -2,6 +2,13 @@
 title: 'Container Logs'
 ---
 
+## How to Log From Your Container
+
+When running a container on SaladCloud, you can log to the standard output and standard error streams. These logs are
+collected and stored by SaladCloud, and exported to any configured external logging source.
+
+## How to View Container Logs In the Portal
+
 Once your container is up and running on a SaladCloud node, you can view the logs from your container on the "Container
 Logs" tab of a Container Group. To access this feature in the portal, navigate to your Container Group details page, and
 click on the 'Container Logs' tab.

--- a/products/sce/container-groups/faqs.mdx
+++ b/products/sce/container-groups/faqs.mdx
@@ -4,9 +4,8 @@ title: 'FAQs'
 
 # How do I use SSH with Salad?
 
-Since SCE is a managed container service running on spot instance like infrastructure SSH is not recommended since the
-session or changes you make could disappear without warning. By putting bundling your application in a container, you
-will be sure that each replica running on SaladCloud is running in a consistent and reproducible way.
+Salad does not support SSH access to containers. If you need to access a running container, you can use the
+[SaladCloud Terminal](/tutorials/interactive-terminal) to execute commands on the container.
 
 # I need a unique URL for each node. How do I do that?
 

--- a/products/sce/introduction.mdx
+++ b/products/sce/introduction.mdx
@@ -120,9 +120,9 @@ docker buildx build --platform linux/amd64,linux/arm64 .
 
 ### Cold-start Overhead
 
-In rare cases, if the Windows Subsystem for Linux utility is not installed on the best available host machine, the Salad
-Bowl daemon must install it before running container workloads within SaladCloud's Linux distribution. This design
-pattern can introduce modest overhead in terms of cold-start time, but should not impact performance or reliability.
+Cold-start times on SaladCLoud can be longer than on traditional clouds. This is primarily due to the time it takes to
+download container images to the host machine. Since host machines are consumer-owned, they often have slower internet
+connections than data centers.
 
 ### Data-sensitivity Compliance
 

--- a/products/sce/introduction.mdx
+++ b/products/sce/introduction.mdx
@@ -99,14 +99,24 @@ build with SCE:
 - use AI models to perform image generation, text to audio, image captioning, and other tasks
 - proxy video-streaming requests for virtual private networks
 - conduct long-running data processing queues
-- execute hyper-threaded, parallelized workloads
+- execute massively parallelizable workloads
 - distribute 3D rendering or VFX queues
 - procedurally-generated mapping simulations
-- access low-latency servers for P2P gaming
 
 # Additional Considerations
 
 Developers interested in using SCE should be aware of these additional considerations:
+
+### AMD64 Architecture
+
+SaladCloud currently **supports only AMD64 architecture** for container instances. ARM architecture **is not supported**
+at this time. If you are developing on a Mac or other ARM-based system, you may need to cross-compile your application
+for AMD64. Docker supports [multi-architecture builds](https://docs.docker.com/build/building/multi-platform/), so you
+can build your application for both ARM and AMD64 at the same time using the `--platform` flag:
+
+```
+docker buildx build --platform linux/amd64,linux/arm64 .
+```
 
 ### Cold-start Overhead
 
@@ -126,6 +136,20 @@ legislative authorities (including but not limited to HIPAA and the Financial Mo
 While SCE does maintain a stable replica count within a given Container Group, SCE deployments do not currently
 auto-scale Container Groups based on performance. Container Groups must be scaled up or down on demand through the
 Portal, or by direct request via the SaladCloud API.
+
+### Persistent Storage
+
+SaladCloud does not currently support persistent storage for container instances. All data written to the container
+instance's filesystem is ephemeral and will be lost when the container instance is terminated. If you need persistent
+storage, you can use an external storage service like Amazon S3, Google Cloud Storage, or Azure Blob Storage. We
+recommend a vendor that does not charge egress fees, as SaladCloud nodes are globally distributed and egress fees can
+add up quickly.
+
+### WSL2
+
+SaladCloud uses Windows Subsystem for Linux 2 (WSL2) to run Linux containers on Windows machines. Customers may notice
+that less than 100% of VRAM is available to the container. This is because WSL2 reserves a small portion of the VRAM for
+the Windows host machine.
 
 ### Performance Variability
 

--- a/products/sce/introduction.mdx
+++ b/products/sce/introduction.mdx
@@ -120,7 +120,7 @@ docker buildx build --platform linux/amd64,linux/arm64 .
 
 ### Cold-start Overhead
 
-Cold-start times on SaladCLoud can be longer than on traditional clouds. This is primarily due to the time it takes to
+Cold-start times on SaladCloud can be longer than on traditional clouds. This is primarily due to the time it takes to
 download container images to the host machine. Since host machines are consumer-owned, they often have slower internet
 connections than data centers.
 


### PR DESCRIPTION
- Specify that container logging is done through `stderr` and `stdout`
- Point to terminal as alternative to ssh
- Explain building for amd64
- Explain why workloads have less than 100% vram in wsl2
- Explain that container instance storage is ephemeral