### PR TITLE
add link to recipes repo for all recipe product pages

### DIFF
--- a/products/recipes/dreamshaper8-comfyui.mdx
+++ b/products/recipes/dreamshaper8-comfyui.mdx
@@ -118,3 +118,7 @@ the docker image
 
 You can see the full API documentation at the `/docs` endpoint at the Access Domain Name of your container group. They
 can also be found in the [API Reference](/reference/recipes/dreamshaper8-comfyui/).
+
+## Source Code
+
+[<Icon icon="github" size="24" /> Github Repository](https://github.com/SaladTechnologies/salad-recipes/tree/master/src/dreamshaper8-comfyui)

--- a/products/recipes/flux1-schnell-fp8-comfyui.mdx
+++ b/products/recipes/flux1-schnell-fp8-comfyui.mdx
@@ -124,3 +124,7 @@ the docker image
 
 You can see the full API documentation at the `/docs` endpoint at the Access Domain Name of your container group. They
 can also be found in the [API Reference](/reference/recipes/flux1-schnell-fp8-comfyui/).
+
+## Source Code
+
+[<Icon icon="github" size="24" /> Github Repository](https://github.com/SaladTechnologies/salad-recipes/tree/master/src/flux1-schnell-fp8-comfyui)

--- a/products/recipes/ollama-llama3.1.mdx
+++ b/products/recipes/ollama-llama3.1.mdx
@@ -113,3 +113,7 @@ Hardware: RTX 3060 with 12GB VRAM System RAM: 8 GB vCPU: 8 vCPUs
 ## API Reference
 
 It can be found in the [API Reference](/reference/recipes/ollama-llama3.1).
+
+## Source Code
+
+[<Icon icon="github" size="24" /> Github Repository](https://github.com/SaladTechnologies/salad-recipes/tree/master/src/ollama-llama3.1)

--- a/products/recipes/sd3.5-large.mdx
+++ b/products/recipes/sd3.5-large.mdx
@@ -115,3 +115,12 @@ reference the new image.
 
 [Learn how to add custom workflows](https://github.com/SaladTechnologies/comfyui-api?tab=readme-ov-file#generating-new-workflow-endpoints)
 to the API server.
+
+## API Reference
+
+You can see the full API documentation at the `/docs` endpoint at the Access Domain Name of your container group. They
+can also be found in the [API Reference](/reference/recipes/sd3.5-large/).
+
+## Source Code
+
+[<Icon icon="github" size="24" /> Github Repository](https://github.com/SaladTechnologies/salad-recipes/tree/master/src/sd3.5-large-comfyui)

--- a/products/recipes/sd3.5-medium.mdx
+++ b/products/recipes/sd3.5-medium.mdx
@@ -116,3 +116,12 @@ reference the new image.
 
 [Learn how to add custom workflows](https://github.com/SaladTechnologies/comfyui-api?tab=readme-ov-file#generating-new-workflow-endpoints)
 to the API server.
+
+## API Reference
+
+You can see the full API documentation at the `/docs` endpoint at the Access Domain Name of your container group. They
+can also be found in the [API Reference](/reference/recipes/sd3.5-medium/).
+
+## Source Code
+
+[<Icon icon="github" size="24" /> Github Repository](https://github.com/SaladTechnologies/salad-recipes/tree/master/src/sd3.5-medium-comfyui)

--- a/products/recipes/sdxl-with-refiner-comfyui.mdx
+++ b/products/recipes/sdxl-with-refiner-comfyui.mdx
@@ -125,3 +125,7 @@ the docker image
 
 You can see the full API documentation at the `/docs` endpoint at the Access Domain Name of your container group. They
 can also be found in the [API Reference](/reference/recipes/sdxl-with-refiner-comfyui/).
+
+## Source Code
+
+[<Icon icon="github" size="24" /> Github Repository](https://github.com/SaladTechnologies/salad-recipes/tree/master/src/sdxl-with-refiner-comfyui)

--- a/products/recipes/yolov8.mdx
+++ b/products/recipes/yolov8.mdx
@@ -146,3 +146,7 @@ Hardware: RTX 3080TI with 12 GB VRAM System RAM: 8 GB vCPU: 8 vCPUs
 
 You can see the full API documentation at the `/docs` endpoint at the Access Domain Name of your container group. They
 can also be found in the [API Reference](/reference/recipes/yolov8).
+
+## Source Code
+
+[<Icon icon="github" size="24" /> Github Repository](https://github.com/SaladTechnologies/salad-recipes/tree/master/src/yolov8)


### PR DESCRIPTION
- Adds a section to the bottom of every recipe page that links to the recipes repo directory that it is built from.
- Adds a link to the api reference for the sd3.5 recipes