### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/scripts/validate-all-workflows.sh
+++ b/.github/scripts/validate-all-workflows.sh
@@ -1,10 +1,10 @@
-#! /usr/bin/bash
+#!/bin/bash
 set -e
 
 api_spec_dir="api-specs"
 
-# Spec can be in json or yaml
+# OpenAPI Specification documents may be JSON or YAML
 for spec in $(find $api_spec_dir -type f -name "*.json" -o -name "*.yaml" -o -name "*.yml"); do
   echo "Validating $spec"
-  npx --yes @apidevtools/swagger-cli validate $spec
+  npx --yes mintlify openapi-check $spec
 done

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply stale policy
-        uses: actions/stale@v8
+        uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 30
@@ -32,7 +32,7 @@ jobs:
             Issues with the labels `no-stale`, `help wanted`, and `good first issue` are exempt from this policy.
 
           stale-pr-label: "stale"
-          exempt-pr-labels: "no-stale"
+          exempt-pr-labels: "dependencies,no-stale"
           stale-pr-message: >
             There hasn't been any activity on this pull request in 30 days.
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,10 @@
       "addWords": true
     }
   },
-  "cSpell.enableFiletypes": ["markdown", "mdx"],
+  "cSpell.enabledFileTypes": {
+    "markdown": true,
+    "mdx": true
+  },
   "cSpell.language": "en,en-US",
   "editor.formatOnSave": true,
   "editor.minimap.maxColumn": 120,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "name": "salad-cloud-docs",
       "version": "1.0.0",
       "dependencies": {
-        "@cspell/dict-pt-br": "^2.3.0",
-        "@cspell/dict-pt-pt": "^3.0.1",
+        "@cspell/dict-pt-br": "^2.3.3",
+        "@cspell/dict-pt-pt": "^3.0.4",
         "cspell-dict-de-de": "^1.2.3",
         "cspell-dict-es-es": "^1.1.2",
         "cspell-dict-fr-fr": "^1.3.1",
         "cspell-dict-it-it": "^1.1.2",
-        "yaml": "^2.5.1"
+        "yaml": "^2.6.1"
       }
     },
     "node_modules/@cspell/dict-de-de": {
@@ -38,14 +38,16 @@
       "integrity": "sha512-HFX1AhvgpUE+mPjYlHABwsaVG/8iL0crcWB37q5oELFhGVb/FzAvrFXK2+MAQoWH0ZnSMdBH32mgEb+gcwoYdQ=="
     },
     "node_modules/@cspell/dict-pt-br": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-pt-br/-/dict-pt-br-2.3.0.tgz",
-      "integrity": "sha512-SUR0xlvcKrNyAXwex1E0Qz4xQ+XZO/pkRSWb9ZHEHCJjGoJgs3j0e0inwX4JvcYUOPisLwh4W2NTKWr+a0NR1w=="
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-pt-br/-/dict-pt-br-2.3.3.tgz",
+      "integrity": "sha512-+638SWd66jVJNinJgFZLsA2uqyIncw6/rubDRBmK/UjQwTRtzf+iuFoP5TTpOsjq9kiVZ2+g+1d854wWVh6mcg==",
+      "license": "GPL-3.0-or-later"
     },
     "node_modules/@cspell/dict-pt-pt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-pt-pt/-/dict-pt-pt-3.0.1.tgz",
-      "integrity": "sha512-+GuJMhU7BgxsYU68D/5+muq9Ulwa1OcjlmWhtaO+1XrwxxFSCPwHQdt069ShRbQhsCmhWY3+owNcsPiKHOdBLQ=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-pt-pt/-/dict-pt-pt-3.0.4.tgz",
+      "integrity": "sha512-UuKwNq9vbCKO6A59xha0xA91yYjZBDgLFZ68EMeITaKlbV/AOpOzu6UqauvhEsW22DCeIgNvabC+4PAml2UhWg==",
+      "license": "LGPL-3.0"
     },
     "node_modules/configstore": {
       "version": "5.0.1",
@@ -226,9 +228,10 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -8,17 +8,15 @@
   },
   "author": "",
   "dependencies": {
-    "@cspell/dict-pt-br": "^2.3.0",
-    "@cspell/dict-pt-pt": "^3.0.1",
+    "@cspell/dict-pt-br": "^2.3.3",
+    "@cspell/dict-pt-pt": "^3.0.4",
     "cspell-dict-de-de": "^1.2.3",
     "cspell-dict-es-es": "^1.1.2",
     "cspell-dict-fr-fr": "^1.3.1",
-    "cspell-dict-it-it": "^1.1.2"
+    "cspell-dict-it-it": "^1.1.2",
+    "yaml": "^2.6.1"
   },
   "ignorePaths": [
     "node_modules/**"
-  ],
-  "devDependencies": {
-    "yaml": "^2.5.1"
-  }
+  ]
 }


### PR DESCRIPTION
This applies some minor updates to the repo's GitHub Actions and project configuration. Notably, it switches from the abandoned `@apidevtools/swagger-cli` to the `mintlify` CLI to validate OpenAPI Specification documents.