### PR TITLE
Adding Security & Email Security to Docs

### DIFF
--- a/products/sce/container-groups/security/email-security.mdx
+++ b/products/sce/container-groups/security/email-security.mdx
@@ -1,0 +1,26 @@
+---
+title: 'Email Security'
+slug: 'email-security'
+description: 'Worried about your account security? If you suspect unauthorized access or attempts to access your SaladCloud account, 
+contact SaladCloud support immediately. For more information on how unauthorized parties might try to gain access, continue reading below.'
+---
+
+### Why did I receive an email from SaladCloud that I did not request?
+
+SaladCloud provides various forms asking for email addresses to help customers resolve login issues, such as our password reset workflow. 
+It's possible that someone else typed in your email address by accident. When this happens, you'll receive an email from Salad with a one-time 
+link to reset your password.
+
+### What do I do when I receive an email from SaladCloud that I did not request?
+
+If you receive an email from SaladCloud that you did not request, do not click on any links within the email. Instead, navigate directly to 
+the SaladCloud Portal and log in to your account. Check your account settings and recent activity for any suspicious changes. If you notice 
+anything unusual, immediately change your password and [contact SaladCloud support](mailto:cloud@salad.com) to report the incident.
+
+### How do I ensure my SaladCloud account and organization information are secure?
+
+Here are some tips to safeguard your account:
+
+- Ensure your email is secure by using a strong password and regularly updating it.
+- Use a long, random password with a minimum of 8 characters, including a mix of letters, numbers, and symbols.
+- Avoid reusing the same password across multiple sites to minimize the risk of breaches.


### PR DESCRIPTION
Adding a main security tab and an email security page to the docs site. While this section is sparse, _for now_, the goal here will be to add additional security resources that are more technical and can be used to reference the security-specific concerns that developers have when testing and onboarding.
