### PR TITLE
Remove references to prepaid billing transition

### DIFF
--- a/products/sce/container-groups/billing-and-pricing/billing.mdx
+++ b/products/sce/container-groups/billing-and-pricing/billing.mdx
@@ -1,22 +1,11 @@
 ---
-title: 'Billing & Pricing'
+title: 'Billing'
 ---
-
-> ℹ️ **Info:** SaladCloud is migrating to prepaid billing for all organizations.
->
-> Please follow the directions below to ensure your account stays active. We will begin enforcing organizations to have
-> a positive credit balance starting on February 1, 2025.
->
-> In the month of January 2025, you must have a positive credit balance or a valid payment method on file to utilize
-> SaladCloud.
-
-We require organizations to have a positive credit balance before running workloads or using our API endpoints. This is
-primarily a means to prevent abuse and ensure that we can collect payment at the end of the month.
 
 # Prepaid Billing
 
-In order to keep your organization's workloads active, you must maintain a positive credit balance. There are two
-options to do this on SaladCloud: Auto Recharge and Manual Recharge.
+SaladCloud used prepaid billing. In order to keep your organization's workloads active, you must maintain a positive
+credit balance. There are two options to do this on SaladCloud: Auto Recharge and Manual Recharge.
 
 ## Auto Recharge
 

--- a/products/sce/container-groups/billing-and-pricing/prepaid-billing-faqs.mdx
+++ b/products/sce/container-groups/billing-and-pricing/prepaid-billing-faqs.mdx
@@ -6,27 +6,7 @@ sidebarTitle: 'Prepaid Billing FAQs'
 This document addresses common questions asked to the SaladCloud support team about our migration to prepaid billing. If
 you have additional questions, please reach out to support at [cloud@salad.com](mailto:cloud@salad.com).
 
-## Why is SaladCloud changing its billing process?
-
-The new update gives customers greater control over their spending with SaladCloud. By transitioning to a prepaid
-billing process, SaladCloud enables faster user verification and unlocks higher usage quotas, allowing customers to
-scale operations more efficiently without the hassle of complex verification procedures.
-
-## Who should review their account and choose a prepaid billing method?
-
-All SaladCloud customers are encouraged to review their organization settings and confirm that a prepaid billing method
-is in place. Organizations have the option to enable Auto Recharge, allowing them to set a credit threshold and
-automatically replenish their account with a specified amount. Alternatively, organizations can maintain a positive
-credit balance through one-time manual credit recharges, with amounts up to $10,000. For detailed instructions,
-[explore our top-up workflows here](https://docs.salad.com/products/sce/container-groups/billing-and-pricing/billing#prepaid-billing).
-
-## When do I need to have my billing information and prepaid preferences set in my account?
-
-Between January 1 and January 31, ensure your billing configuration is complete. Starting February 1, SaladCloud will
-enforce automatic shutdowns for accounts with a zero or negative credit balance. Don’t wait—set up your prepaid billing
-settings today!
-
-## How does this new system work?
+## How does SaladCloud's prepaid system work?
 
 Prepaid credits are used to run workloads on SaladCloud, offering two recharge options: automatic and manual. With
 automatic recharges, you can set a predefined credit amount to automatically top up your balance when it falls below a
@@ -75,11 +55,6 @@ a positive credit balance. The best way to ensure you keep your credit balance p
 your account. If we detect an error with an Auto or Manual Recharge event, we will immediately send you an email
 notification with directions for how to resolve the issue.
 
-## What happens if I do not have a positive credit balance before February 1st?
-
-All active instances will be paused, and API usage will be restricted until the required information is provided and
-credits are successfully applied.
-
 ## What happens if I have remaining credits after a test or a batch job on SaladCloud?
 
 All credits purchases are final and expire 12 months from purchase date.
@@ -92,6 +67,6 @@ before the next monthly renewal, SaladCloud will restrict your access until the 
 any interruption in service, you can add Auto Recharge or make a one-time Manual Recharge to purchase additional credits
 for your organization; however, this is optional.
 
-## Who do I reach out to with other questions about this change?
+## Who do I reach out to with other questions?
 
 Please reach out to support via [cloud@salad.com](mailto:cloud@salad.com).


### PR DESCRIPTION
We've now transitioned to prepaid billing, so transition directions are no longer relevant. Also removed "& Pricing" form the title - I wouldn't consider this page to have pricing info. 
