### PR TITLE
Hiding queues from portal

### DIFF
--- a/guides/image-generation/deploy-video-gen-on-salad-with-comfy.mdx
+++ b/guides/image-generation/deploy-video-gen-on-salad-with-comfy.mdx
@@ -864,9 +864,7 @@ RUN wget https://github.com/SaladTechnologies/salad-cloud-job-queue-worker/relea
 CMD ["bash", "-c", "./salad-http-job-queue-worker & ./comfyui-api"]
 ```
 
-Next, we need to create a Job Queue in the [SaladCloud portal](https://portal.salad.com).
-
-![](/guides/image-generation/images/create-video-gen-job-queue.png)
+Next, we need to create a Job Queue with the [Job Queue API](/reference/saladcloud-api/queues/create-a-queue).
 
 ## Step 6: Deploy to SaladCloud
 

--- a/products/sce/job-queues/creating-a-job-queue.mdx
+++ b/products/sce/job-queues/creating-a-job-queue.mdx
@@ -4,12 +4,7 @@ title: 'Creating a Job Queue'
 
 # Using the Portal
 
-Create a Job Queue in the Portal by clicking the Job Queues link in the left sidebar, then selecting 'Create New Job
-Queue'. Enter a name for your job queue and press 'Create'.
-
-<img src="/products/sce/job-queues/images/portal-job-queues.png" />
-
-<img src="/products/sce/job-queues/images/portal-create-new-job-queue.png" />
+Create a Job Queue with the [Job Queue API](/reference/saladcloud-api/queues/create-a-queue).
 
 > 📘 Job Queue Connections
 >

--- a/products/sce/job-queues/creating-a-job-queue.mdx
+++ b/products/sce/job-queues/creating-a-job-queue.mdx
@@ -2,7 +2,7 @@
 title: 'Creating a Job Queue'
 ---
 
-# Using the Portal
+# Using the Public API
 
 Create a Job Queue with the [Job Queue API](/reference/saladcloud-api/queues/create-a-queue).
 

--- a/products/sce/job-queues/job-queues.mdx
+++ b/products/sce/job-queues/job-queues.mdx
@@ -7,6 +7,19 @@ With Job Queues you configure a port on your container, deploy your container gr
 endpoint. These requests are automatically queued and distributed to healthy nodes, with automatic retries to handle
 transient failures.
 
+# Limitations
+
+- Our Job Queues are designed to distribute tasks to an HTTP server, and queue operations are managed with http response
+  symantics, e.g. return 200 for a successful job, 500 for a failed job.
+- Jobs will be retried up to 3 times (meaning 4 total attempts) before being marked as failed. This limitation in
+  combination with interruptible instances means our job queues are not well suited for extremely long running tasks.
+- Instance interruptions count as job failures, and those jobs will be retried according to the above policy.
+- Jobs are not guaranteed to be processed in order, but they will be processed in a FIFO manner.
+- Jobs are not guaranteed to be processed by the same node, but they will be processed by a healthy node.
+- The response body from your http server cannot exceed 10MB.
+- Job Queues can only be managed and accessed via the
+  [Job Queue API](http://localhost:3000/reference/saladcloud-api/queues/create-a-queue)
+
 # Terminology
 
 - **Job:** An individual request to be processed. An example of a job might be a token string sent to an image


### PR DESCRIPTION
- We have removed job queues from the portal, and they are now an api only feature. This updates a couple places that referenced using the portal to instead direct to the create job queue endpoint in reference.