### PR TITLE
Migration guides callout on front page

### DIFF
--- a/products/documentation.mdx
+++ b/products/documentation.mdx
@@ -31,20 +31,30 @@ Check out our step-by-by guides to migrate your transcription workloads from oth
   <Card
     title="Azure Batch Transcription"
     href="/guides/transcription/salad-transcription-api/migrate-to-salad-transcription-api/migrate-from-azure-batch"
+    horizontal
   >
     Migrate from Azure Batch Transcription to Salad Transcription API
   </Card>
   <Card
     title="Google Cloud Speech-to-Text"
     href="/guides/transcription/salad-transcription-api/migrate-to-salad-transcription-api/migrate-from-gcp-transcription"
+    horizontal
   >
     Migrate from Google Cloud Speech-to-Text to Salad Transcription API
   </Card>
   <Card
     title="Rev Transcription"
     href="/guides/transcription/salad-transcription-api/migrate-to-salad-transcription-api/migrate-from-rev-transcription"
+    horizontal
   >
     Migrate from Rev Transcription to Salad Transcription API
+  </Card>
+  <Card
+    title="AssemblyAI Transcription"
+    href="/guides/transcription/salad-transcription-api/migrate-to-salad-transcription-api/migrate-from-assembly-transcription"
+    horizontal
+  >
+    Migrate from AssemblyAI Transcription to Salad Transcription API
   </Card>
 </CardGroup>
 

--- a/products/documentation.mdx
+++ b/products/documentation.mdx
@@ -20,6 +20,34 @@ their compute time. You can think of it like AirBnB for compute.
 [Learn more about how SaladCloud works](/products/sce/introduction), and how we ensure
 [security](https://salad.com/security) and privacy for both device owners and container operators.
 
+## Migrating From Other Providers
+
+### Transcription API
+
+Check out our step-by-by guides to migrate your transcription workloads from other providers to
+[Salad Transcription API](/products/transcription).
+
+<CardGroup>
+  <Card
+    title="Azure Batch Transcription"
+    href="/guides/transcription/salad-transcription-api/migrate-to-salad-transcription-api/migrate-from-azure-batch"
+  >
+    Migrate from Azure Batch Transcription to Salad Transcription API
+  </Card>
+  <Card
+    title="Google Cloud Speech-to-Text"
+    href="/guides/transcription/salad-transcription-api/migrate-to-salad-transcription-api/migrate-from-gcp-transcription"
+  >
+    Migrate from Google Cloud Speech-to-Text to Salad Transcription API
+  </Card>
+  <Card
+    title="Rev Transcription"
+    href="/guides/transcription/salad-transcription-api/migrate-to-salad-transcription-api/migrate-from-rev-transcription"
+  >
+    Migrate from Rev Transcription to Salad Transcription API
+  </Card>
+</CardGroup>
+
 ## Browse by Product
 
 SaladCloud offers a variety of products to meet your needs. Select a product below to get started.


### PR DESCRIPTION
Trying out front-page callouts for migration guides