### PR TITLE
Removes Portal instructions for setting up autoscaling

### DIFF
--- a/products/sce/autoscaling/enable-autoscaling.mdx
+++ b/products/sce/autoscaling/enable-autoscaling.mdx
@@ -2,47 +2,7 @@
 title: 'Set Up Autoscaling'
 ---
 
-You can enable the autoscaling feature in SaladCloud through the portal or via the API. Here's how:
-
-## Using the Portal
-
-1. **Create or Edit a Container Group**:
-
-   - In the SaladCloud portal, create a new container group or edit an existing one.
-   - **Note**: You can only configure your Job Queue connection when creating a new container group. If the container is
-     not connected to a job queue during creation, you will not be able to retrospectively add the job queue connection
-     later through the "Edit Container" wizard. This differs from the autoscaling settings, which can be added or edited
-     later for any container group that has an active queue connection.
-
-2. **Enable the Job Queue**:
-
-   - Ensure that your container group is configured to use the Job Queue, which the autoscaler monitors to determine
-     scaling behavior. You can find detailed instructions on how to enable the Job Queue
-     [here](/products/sce/job-queues/creating-a-job-queue)
-
-3. **Configure Autoscaling Settings**:
-
-- Under the **Job Queue** section, select `Enable Autoscaling` to reveal the autoscaling settings.
-
-<img src="/products/sce/autoscaling/images/autoscaling-1.png" />
-
-- Under the **Autoscaling** section, configure the desired settings such as `Desired Queue Length`, `Minimum Replicas`,
-  `Maximum Replicas`, `Period`, and optional settings like `Maximum Upscale Per Minute` and
-  `Maximum Downscale Per Minute`. Check the [Autoscaling Settings](/products/sce/autoscaling/settings) for more details.
-
-  <img src="/products/sce/autoscaling/images/autoscaling-2.png" />
-
-4. **Save and Deploy**:
-   - After configuring the settings, save the changes and deploy the container group. The autoscaler will begin
-     monitoring the queue and scaling container instances after the first message is sent to the queue.
-
-**Note:** You still need to specify replica count in the container group configuration. This number will be used the
-first message is sent to the queue. Once that happens autoscaller will take over and adjust the replica count based on
-queue length.
-
-## Using the API
-
-You can also configure autoscaling programmatically using SaladCloud's API.
+You can enable the autoscaling feature in SaladCloud via the API. Here's how:
 
 1. **Create a Container Group**: Use the SaladCloud API to create a container group. Ensure that the Job Queue is
    enabled in the configuration.


### PR DESCRIPTION
We don't have autoscaling options in the Portal, so removing them from docs