### PR TITLE
add a card to front page for migration guide

### DIFF
--- a/products/documentation.mdx
+++ b/products/documentation.mdx
@@ -56,6 +56,13 @@ Check out our step-by-by guides to migrate your transcription workloads from oth
   >
     Migrate from AssemblyAI Transcription to Salad Transcription API
   </Card>
+  <Card
+    title="Amazon Transcribe"
+    href="/guides/transcription/salad-transcription-api/migrate-to-salad-transcription-api/migrate-from-aws-transcription"
+    horizontal
+  >
+    Migrate from Amazon Transcribe to Salad Transcription API
+  </Card>
 </CardGroup>
 
 ## Browse by Product


### PR DESCRIPTION
Puts a card to the amazon transcribe migration guide on the front page