### PR TITLE
add card for deepgram to front page

### DIFF
--- a/products/documentation.mdx
+++ b/products/documentation.mdx
@@ -4,7 +4,7 @@ description: 'Information, Tutorials, How-To Guides and API Reference for SaladC
 sidebarTitle: 'Introduction'
 ---
 
-_Last Updated: March 06, 2025_
+_Last Updated: March 20, 2025_
 
 ## Introduction
 
@@ -64,6 +64,13 @@ Check out our step-by-by guides to migrate your transcription workloads from oth
     horizontal
   >
     Migrate from Amazon Transcribe to Salad Transcription API
+  </Card>
+  <Card
+    title="Deepgram"
+    href="/guides/transcription/salad-transcription-api/migrate-to-salad-transcription-api/migrate-from-deepgram-transcription"
+    horizontal
+  >
+    Migrate from Deepgram to Salad Transcription API
   </Card>
 </CardGroup>
 

--- a/products/sce/faqs.mdx
+++ b/products/sce/faqs.mdx
@@ -3,7 +3,7 @@ title: 'Salad Container Engine FAQs'
 sidebarTitle: 'FAQs'
 ---
 
-_Last Updated: January 09, 2025_
+_Last Updated: March 17, 2025_
 
 This document is a must-read before getting started with SaladCloud. Here, we detail what SaladCloud is, the nature of
 our network, how SaladCloud works, unique traits of our distributed network, the choice of consumer GPUs over data


### PR DESCRIPTION
- Adds migration card for deepgram to the front page with the rest of the transcription migration guides.
- fix "last updated"