### PR TITLE
update docs that reference job queue in portal

### DIFF
--- a/guides/image-generation/deploy-video-gen-on-salad-with-comfy.mdx
+++ b/guides/image-generation/deploy-video-gen-on-salad-with-comfy.mdx
@@ -899,44 +899,24 @@ docker push saladtechnologies/comfyui:video-gen-example
 
 This may take some time, depending on your network speed. Once it's done, you can deploy your container to SaladCloud.
 
-Navigate to the [SaladCloud portal](https://portal.salad.com), and click on the Container Groups tab. Click "Get
-Started" in the Custom Container Group section.
+Because we are using the Job Queue, we need to create a new Container Group with the
+[Public API](/reference/saladcloud-api/container_groups/create-a-container-group). This functionality is not available
+in the portal.
 
-![](/guides/image-generation/images/create-container-group.png)
-
-We're going to start with 3 replicas, and set the container image to the one we just pushed.
-
-![](/guides/image-generation/images/video-gen-service-create-page-1.png)
-
-We're going to use 4 vCPU, 30GB of RAM, and an RTX 4090 GPU.
-
-![](/guides/image-generation/images/video-gen-service-cpu-and-mem.png)
-
-![](/guides/image-generation/images/video-gen-service-gpu.png)
-
-We're going to set the priority to "High", although if your usecase is not time-sensitive, you can achieve significant
-cost savings by reducing the workload priority. Lower priority workloads can be preempted by higher priority workloads.
-Additionally, we're going to reserve 1GB of additional storage, for the temporary storage of video files. ComfyUI API
-cleans up after itself, but it's good to have a little extra space just in case.
-
-![](/guides/image-generation/images/video-gen-service-priority-and-storage.png)
-
-On the right side of the screen, you'll see a cost estimation that reflects our current selection.
-
-![](/guides/image-generation/images/video-gen-service-cost.png)
-
-Next, we're going to connect the container group to the job queue we made in the previous step. Configure the job queue
-for port 3000 (where our API is running), and set the path to `/workflow/video-clip`, which is the endpoint we created.
-For this tutorial, we won't enable autoscaling, but you
-[learn more about it here](/products/sce/autoscaling/autoscaling#autoscaling-overview).
-
-![](/guides/image-generation/images/video-gen-service-connect-job-queue.png)
-
-Finally, we will configure the readiness probe to check the `/ready` endpoint, and set the container group to start with
-
-![](/guides/image-generation/images/video-gen-service-readiness-probe.png)
-
-Finally, ensure "Autostart container group once image is pulled" is selected, and click "Deploy".
+- We're going to start with 3 replicas, and set the container image to the one we just pushed.
+- We're going to use 4 vCPU, 30GB of RAM, and an RTX 4090 GPU.
+- We're going to set the priority to "High", although if your usecase is not time-sensitive, you can achieve significant
+  cost savings by reducing the workload priority. Lower priority workloads can be preempted by higher priority
+  workloads.
+- Additionally, we're going to reserve 1GB of additional storage, for the temporary storage of video files. ComfyUI API
+  cleans up after itself, but it's good to have a little extra space just in case.
+- We're going to connect the container group to the job queue we made in the previous step. Configure the job queue for
+  port 3000 (where our API is running), and set the path to `/workflow/video-clip`, which is the endpoint we created.
+  For this tutorial, we won't enable autoscaling, but you can
+  [learn more about it here](/products/sce/autoscaling/autoscaling#autoscaling-overview).
+- Finally, we will configure the readiness probe to check the `/ready` endpoint
+- Finally, ensure `autostart_policy` is set to `true` so that the container group starts automatically once the image is
+  pulled into our internal cache.
 
 At this point, Salad will pull the container image into our own high-performance container image cache. You will see
 this as a "preparing" status on the container group page.

--- a/products/sce/job-queues/creating-a-job-queue.mdx
+++ b/products/sce/job-queues/creating-a-job-queue.mdx
@@ -2,32 +2,22 @@
 title: 'Creating a Job Queue'
 ---
 
-_Last Updated: February 14, 2025_
+_Last Updated: March 24, 2025_
 
 # Using the Public API
 
-Create a Job Queue with the [Job Queue API](/reference/saladcloud-api/queues/create-a-queue).
+Job Queues are not available through the portal, but you can create a Job Queue with the
+[Job Queue API](/reference/saladcloud-api/queues/create-a-queue). You will also need to
+[create your container group](/reference/saladcloud-api/container_groups/create-a-container-group) via the public API in
+order to attach a job queue to it.
+[Ensure your container image includes the job queue worker](products/sce/job-queues/queue-worker)
 
 > 📘 Job Queue Connections
 >
 > A Job Queue can be connected to multiple container groups at once. but a container group can only be connected to at
 > most a single Job Queue.
 
-When configuring a new container group, click the 'Edit' link next to the Job Queues card:
-
-<img src="/products/sce/job-queues/images/portal-enable-job-queue.png" />
-
-Select your previously-created Job Queue from the 'Select a Job Queue' dropdown. (If you haven't yet created a Job
-Queue, press the 'Create New Job Queue' button and do so before returning to this page).
-
-<img src="/products/sce/job-queues/images/portal-configure-job-queue.png" />
-
-Enter the Port and Path of your application that you identified during the
-[Configuring the Job Queue Worker](/products/sce/job-queues/queue-worker) step. This information will be attached to
-jobs sent to the Queue Worker so that it knows where to post them to the application running inside the deployed
-container.
-
-**We also recommend adding a [readiness probe](/products/sce/container-groups/health-probes/readiness-probes) to your
+**We recommend adding a [readiness probe](/products/sce/container-groups/health-probes/readiness-probes) to your
 container deployment**. This probe will allow your replica to announce to the Job Queue Service when it's ready to
 receive and process jobs. We recommend using it in conjunction with a startup probe. Readiness probes will start to run
 after a startup probe succeeds. Without a startup or readiness probe, the Job Queue Worker will immediately start to
@@ -42,8 +32,7 @@ example below, this is what we have. If your container does not contain a way to
 add one of your own. You can usually find any references to this in the readme or documentation for the container image
 you are using. Readiness probes can flip between passing and failing, and will continue to check until it’s ready to go.
 
-```json
-Enabled
+```yml
 Protocol: HTTP/1.X
 Path: /hc
 Port: 8000
@@ -54,8 +43,3 @@ Timeout Seconds: 1
 Success Threshold: 1
 Failure Threshold: 3
 ```
-
-<img src="/products/sce/job-queues/images/portal-configure-readiness-probe.png" />
-
-Finally, finish configuring your container group before deploying it. When selecting your image source, ensure you
-select the container image you configured in the previous step.


### PR DESCRIPTION
We missed a couple places that referenced job queues in the portal. they are an api-only feature currently.
