### PR TITLE
Update image gen guides

### DIFF
--- a/guides/image-generation/basic-how-to-deploy-flux-on-salad-comfy.mdx
+++ b/guides/image-generation/basic-how-to-deploy-flux-on-salad-comfy.mdx
@@ -23,9 +23,9 @@ Find a docker image of ComfyUI. Here's one we've verified works on Salad:
 
 **ComfyUI**
 
-- Git Repo: [https://github.com/ai-dock/comfyui](https://github.com/ai-dock/comfyui)
+- Git Repo: [ComfyUI API](https://github.com/SaladTechnologies/comfyui-api)
 - Docker Image:
-  [ghcr.io/ai-dock/comfyui:v2-cuda-12.1.1-base-22.04-v0.2.0](http://ghcr.io/ai-dock/comfyui:v2-cuda-12.1.1-base-22.04-v0.2.0)
+  [ghcr.io/saladtechnologies/comfyui-api:comfy0.3.27-torch2.6.0-cuda12.4-runtime](ghcr.io/saladtechnologies/comfyui-api:comfy0.3.27-torch2.6.0-cuda12.4-runtime)
 - Model Directory: `/opt/ComfyUI/models`
 - Custom Node Directory: `/opt/ComfyUI/custom_nodes/`
 
@@ -65,10 +65,8 @@ convenient fp8 checkpoint because it runs well on consumer gpus, and allows for 
 
 ```docker
 # We're going to use this verified comfyui image as a base
-FROM ghcr.io/ai-dock/comfyui:v2-cuda-12.1.1-base-22.04-v0.2.0
+FROM ghcr.io/saladtechnologies/comfyui-api:comfy0.3.27-torch2.6.0-cuda12.4-runtime
 
-# Disable the authentication provided by the base image
-ENV WEB_ENABLE_AUTH=false
 # Startup can take a little longer with larger models.
 # This configures the worker binary's built-in health check.
 ENV STARTUP_CHECK_MAX_TRIES=30
@@ -81,7 +79,7 @@ COPY flux1-schnell-fp8.safetensors ${CHECKPOINT_DIR}/
 # We also need to copy the comfyui-api binary into the image, since ComfyUI
 # is fully asynchronous by default, and has no convenient way to retrieve
 # generated images.
-ADD https://github.com/SaladTechnologies/comfyui-api/releases/download/1.4.0/comfyui-api .
+ADD https://github.com/SaladTechnologies/comfyui-api/releases/download/1.8.2/comfyui-api .
 RUN chmod +x comfyui-api
 
 # OPTIONAL: Warmup the server by running a workflow before starting the server.
@@ -103,14 +101,14 @@ receiving the generated images in the response body, or having complete images s
 1. Build the docker image. You should change the specified tag to suit your purpose.
 
 ```bash
-docker build -t saladtechnologies/comfyui:comfy0.2.0-api1.4.0-flux1-schnell-fp8 .
+docker build -t saladtechnologies/comfyui:comfy0.3.27-api1.8.2-flux1-schnell-fp8 .
 ```
 
 2.  (Recommended) Run the docker image locally to confirm it works as expected
 
     ```bash
     docker run -it --rm --gpus all -p 3000:3000 -p 8188:8188 --name comfyui \
-    saladtechnologies/comfyui:comfy0.2.0-api1.4.0-flux1-schnell-fp8
+    saladtechnologies/comfyui:comfy0.3.27-api1.8.2-flux1-schnell-fp8
     ```
 
     Using it here locally, we’re going to expose port 3000, which is required for the wrapper, and port 8188 that will

--- a/guides/image-generation/basic-how-to-deploy-flux-on-salad-comfy.mdx
+++ b/guides/image-generation/basic-how-to-deploy-flux-on-salad-comfy.mdx
@@ -3,7 +3,7 @@ title: 'How to Deploy Flux (ComfyUI)'
 description: 'A guide to deploying Flux1-Schnell on SaladCloud with ComfyUI'
 ---
 
-_Last Updated: October 10, 2024_
+_Last Updated: March 25, 2025_
 
 ![Deploy Flux on Salad, generated in flux](/guides/image-generation/images/deploy-flux-5.png)
 
@@ -264,7 +264,7 @@ docker build -t saladtechnologies/comfyui:comfy0.3.27-api1.8.2-flux1-schnell-fp8
 1. Push your docker image up to docker hub (or the container registry of your choice.)
 
 ```bash
-docker push saladtechnologies/comfyui:comfy0.2.0-api1.4.0-flux1-schnell-fp8
+docker push saladtechnologies/comfyui:comfy0.3.27-api1.8.2-flux1-schnell-fp8
 ```
 
 2. Deploy your image on Salad, using either the [Portal](https://portal.salad.com) or the

--- a/guides/image-generation/basic-how-to-deploy-flux-on-salad-comfy.mdx
+++ b/guides/image-generation/basic-how-to-deploy-flux-on-salad-comfy.mdx
@@ -25,7 +25,7 @@ Find a docker image of ComfyUI. Here's one we've verified works on Salad:
 
 - Git Repo: [ComfyUI API](https://github.com/SaladTechnologies/comfyui-api)
 - Docker Image:
-  [ghcr.io/saladtechnologies/comfyui-api:comfy0.3.27-torch2.6.0-cuda12.4-runtime](ghcr.io/saladtechnologies/comfyui-api:comfy0.3.27-torch2.6.0-cuda12.4-runtime)
+  [ghcr.io/saladtechnologies/comfyui-api:comfy0.3.27-torch2.6.0-cuda12.4-runtime](https://github.com/SaladTechnologies/comfyui-api/pkgs/container/comfyui-api/versions)
 - Model Directory: `/opt/ComfyUI/models`
 - Custom Node Directory: `/opt/ComfyUI/custom_nodes/`
 

--- a/guides/image-generation/basic-how-to-deploy-stable-diffusion-on-salad-comfy.mdx
+++ b/guides/image-generation/basic-how-to-deploy-stable-diffusion-on-salad-comfy.mdx
@@ -23,7 +23,7 @@ Find a docker image of ComfyUI. Here's one we've verified works on Salad:
 
 - Git Repo: [ComfyUI API](https://github.com/SaladTechnologies/comfyui-api)
 - Docker Image:
-  [ghcr.io/saladtechnologies/comfyui-api:comfy0.3.27-torch2.6.0-cuda12.4-runtime](ghcr.io/saladtechnologies/comfyui-api:comfy0.3.27-torch2.6.0-cuda12.4-runtime)
+  [ghcr.io/saladtechnologies/comfyui-api:comfy0.3.27-torch2.6.0-cuda12.4-runtime](https://github.com/SaladTechnologies/comfyui-api/pkgs/container/comfyui-api/versions)
 - Model Directory: `/opt/ComfyUI/models`
 - Custom Node Directory: `/opt/ComfyUI/custom_nodes/`
 

--- a/guides/image-generation/basic-how-to-deploy-stable-diffusion-on-salad-comfy.mdx
+++ b/guides/image-generation/basic-how-to-deploy-stable-diffusion-on-salad-comfy.mdx
@@ -3,7 +3,7 @@ title: 'How to Deploy Stable Diffusion (ComfyUI)'
 description: 'A guide to deploying a custom stable diffusion model on SaladCloud with ComfyUI'
 ---
 
-_Last Updated: October 10, 2024_
+_Last Updated: March 25, 2025_
 
 # High Level
 
@@ -21,9 +21,9 @@ Find a docker image of ComfyUI. Here's one we've verified works on Salad:
 
 **ComfyUI**
 
-- Git Repo: [https://github.com/ai-dock/comfyui](https://github.com/ai-dock/comfyui)
+- Git Repo: [ComfyUI API](https://github.com/SaladTechnologies/comfyui-api)
 - Docker Image:
-  [ghcr.io/ai-dock/comfyui:v2-cuda-12.1.1-base-22.04-v0.2.0](http://ghcr.io/ai-dock/comfyui:v2-cuda-12.1.1-base-22.04-v0.2.0)
+  [ghcr.io/saladtechnologies/comfyui-api:comfy0.3.27-torch2.6.0-cuda12.4-runtime](ghcr.io/saladtechnologies/comfyui-api:comfy0.3.27-torch2.6.0-cuda12.4-runtime)
 - Model Directory: `/opt/ComfyUI/models`
 - Custom Node Directory: `/opt/ComfyUI/custom_nodes/`
 
@@ -61,10 +61,7 @@ Download any model files you plan to use. For our example, we’re going to use
 
 ```docker
 # We're going to use this verified comfyui image as a base
-FROM ghcr.io/ai-dock/comfyui:v2-cuda-12.1.1-base-22.04-v0.2.0
-
-# Disable the authentication provided by the base image
-ENV WEB_ENABLE_AUTH=false
+FROM ghcr.io/saladtechnologies/comfyui-api:comfy0.3.27-torch2.6.0-cuda12.4-runtime
 
 # Now we copy our model into the image
 ENV MODEL_DIR=/opt/ComfyUI/models
@@ -73,7 +70,7 @@ COPY dreamshaper_8.safetensors ${MODEL_DIR}/checkpoints/dreamshaper_8.safetensor
 # We also need to copy the comfyui-api binary into the image, since ComfyUI
 # is fully asynchronous by default, and has no convenient way to retrieve
 # generated images.
-ADD https://github.com/SaladTechnologies/comfyui-api/releases/download/1.4.0/comfyui-api .
+ADD https://github.com/SaladTechnologies/comfyui-api/releases/download/1.8.2/comfyui-api .
 RUN chmod +x comfyui-api
 
 # OPTIONAL: Warmup the server by running a workflow before starting the server.
@@ -93,17 +90,17 @@ receiving the generated images in the response body, or having complete images s
 ## Build and Test Your Docker Image
 
 1. Build the docker image. You should change the specified tag to suit your purpose. We've chosen to include the ComfyUI
-   version (0.2.0), the API version (1.4.0) and the model name (dreamshaper8) in the tag.
+   version (0.3.27), the API version (1.8.2) and the model name (dreamshaper8) in the tag.
 
 ```bash
-docker build -t saladtechnologies/comfyui:comfy0.2.0-api1.4.0-dreamshaper8 .
+docker build -t saladtechnologies/comfyui:comfy0.3.27-api1.8.2-dreamshaper8 .
 ```
 
 2. (Recommended) Run the docker image locally to confirm it works as expected
 
    ```bash
    docker run -it --rm --gpus all -p 3000:3000 -p 8188:8188 --name comfyui \
-   saladtechnologies/comfyui:comfy0.2.0-api1.4.0-dreamshaper8
+   saladtechnologies/comfyui:comfy0.3.27-api1.8.2-dreamshaper8
    ```
 
    Using it here locally, we’re going to expose port 3000, which is required for the wrapper, and port 8188 that will
@@ -257,7 +254,7 @@ docker build -t saladtechnologies/comfyui:comfy0.2.0-api1.4.0-dreamshaper8 .
 1. Push your docker image up to docker hub (or the container registry of your choice.)
 
 ```bash
-docker push saladtechnologies/comfyui:comfy0.2.0-api1.4.0-dreamshaper8
+docker push saladtechnologies/comfyui:comfy0.3.27-api1.8.2-dreamshaper8
 ```
 
 2. Deploy your image on Salad, using either the [Portal](https://portal.salad.com) or the

--- a/guides/image-generation/deploy-video-gen-on-salad-with-comfy.mdx
+++ b/guides/image-generation/deploy-video-gen-on-salad-with-comfy.mdx
@@ -87,7 +87,7 @@ Create another new file, and name it `Dockerfile`. This file will contain the in
 image. Add the following content to the file:
 
 ```dockerfile
-FROM ghcr.io/saladtechnologies/comfyui-api:comfy0.3.12-api1.8.2-torch2.5.0-cuda12.1-devel
+FROM ghcr.io/saladtechnologies/comfyui-api:comfy0.3.27-api1.8.2-torch2.6.0-cuda12.4-devel
 
 # Video generation requires a few extra dependencies from the base image
 RUN apt-get update && apt-get install -y \

--- a/products/recipes/dreamshaper8-comfyui.mdx
+++ b/products/recipes/dreamshaper8-comfyui.mdx
@@ -2,7 +2,7 @@
 title: Dreamshaper 8 - ComfyUI (API)
 ---
 
-_Last Updated: December 04, 2024_
+_Last Updated: March 25, 2025_
 
 <Tip>Deploy from the [SaladCloud Portal](https://portal.salad.com).</Tip>
 <Note>See the [Benchmark](https://blog.salad.com/stable-diffusion-1-5/) for performance information.</Note>
@@ -15,7 +15,7 @@ generation model by Lykon, fine-tuned from
 [ComfyUI](https://github.com/comfyanonymous/ComfyUI/), exposed via
 [a simple HTTP API](https://github.com/SaladTechnologies/comfyui-api) to facilitate scalable stateless operation. Users
 can make an HTTP request to the provided endpoints and get back one or more images in base64 encoded form. Optionally,
-users can receive completed images via a webhook.
+users can receive completed images via a webhook. **THIS RECIPE DOES NOT SERVE THE WEB UI**.
 
 Dreamshaper 8 is notable for a number of reasons:
 

--- a/products/recipes/flux1-dev-fp8-comfyui.mdx
+++ b/products/recipes/flux1-dev-fp8-comfyui.mdx
@@ -2,7 +2,7 @@
 title: Flux.1-Dev (FP8) - ComfyUI (API)
 ---
 
-_Last Updated: December 06, 2024_
+_Last Updated: March 25, 2025_
 
 <Info>
   **NOTE**: This model is released under a [non-commercial
@@ -18,7 +18,7 @@ generation model by Black Forest Labs, specifically [this FP8 version](https://h
 provided by the Comfy Org. Inference is powered by [ComfyUI](https://github.com/comfyanonymous/ComfyUI/), exposed via
 [a simple HTTP API](https://github.com/SaladTechnologies/comfyui-api) to facilitate scalable stateless operation. Users
 can make an HTTP request to the provided endpoints and get back one or more images in base64 encoded form. Optionally,
-users can receive completed images via a webhook.
+users can receive completed images via a webhook. **THIS RECIPE DOES NOT SERVE THE WEB UI**.
 
 FLUX.1-Dev is notable for several features:
 

--- a/products/recipes/flux1-schnell-fp8-comfyui.mdx
+++ b/products/recipes/flux1-schnell-fp8-comfyui.mdx
@@ -2,7 +2,7 @@
 title: FLUX.1-Schnell (FP8) - ComfyUI (API)
 ---
 
-_Last Updated: December 04, 2024_
+_Last Updated: March 25, 2025_
 
 <Tip>Deploy from the [SaladCloud Portal](https://portal.salad.com).</Tip>
 <Note>See the [Benchmark](https://blog.salad.com/flux1-schnell/) for performance information.</Note>
@@ -15,7 +15,7 @@ image generation model by Black Forest Labs, specifically
 [ComfyUI](https://github.com/comfyanonymous/ComfyUI/), exposed via
 [a simple HTTP API](https://github.com/SaladTechnologies/comfyui-api) to facilitate scalable stateless operation. Users
 can make an HTTP request to the provided endpoints and get back one or more images in base64 encoded form. Optionally,
-users can receive completed images via a webhook.
+users can receive completed images via a webhook. **THIS RECIPE DOES NOT SERVE THE WEB UI**.
 
 FLUX.1-Schnell is notable for several features:
 

--- a/products/recipes/sd3.5-large.mdx
+++ b/products/recipes/sd3.5-large.mdx
@@ -2,7 +2,7 @@
 title: Stable Diffusion 3.5 Large - ComfyUI(API)
 ---
 
-_Last Updated: December 04, 2024_
+_Last Updated: March 25, 2025_
 
 <Tip>Deploy from the [SaladCloud Portal](https://portal.salad.com).</Tip>
 
@@ -13,7 +13,7 @@ This recipe creates an inference API for
 Stability AI. Inference is powered by [ComfyUI](https://github.com/comfyanonymous/ComfyUI/), exposed via
 [a simple HTTP API](https://github.com/SaladTechnologies/comfyui-api) to facilitate scalable stateless operation. Users
 can make an HTTP request to the provided endpoints and get back one or more images in base64 encoded form. Optionally,
-users can receive completed images via a webhook.
+users can receive completed images via a webhook. **THIS RECIPE DOES NOT SERVE THE WEB UI**.
 
 Stable Diffusion 3.5 Large is a large-scale image generation model that can generate high-quality images across a wide
 variety of art styles.

--- a/products/recipes/sd3.5-medium.mdx
+++ b/products/recipes/sd3.5-medium.mdx
@@ -2,7 +2,7 @@
 title: Stable Diffusion 3.5 Medium - ComfyUI(API)
 ---
 
-_Last Updated: December 04, 2024_
+_Last Updated: March 25, 2025_
 
 <Tip>Deploy from the [SaladCloud Portal](https://portal.salad.com).</Tip>
 
@@ -13,7 +13,7 @@ This recipe creates an inference API for
 Stability AI. Inference is powered by [ComfyUI](https://github.com/comfyanonymous/ComfyUI/), exposed via
 [a simple HTTP API](https://github.com/SaladTechnologies/comfyui-api) to facilitate scalable stateless operation. Users
 can make an HTTP request to the provided endpoints and get back one or more images in base64 encoded form. Optionally,
-users can receive completed images via a webhook.
+users can receive completed images via a webhook. **THIS RECIPE DOES NOT SERVE THE WEB UI**.
 
 Stable Diffusion 3.5 Medium is a smaller model in the Stable Diffusion 3.5 model, and is capable of generating
 high-quality images across a wide variety of art styles. It is faster than the larger model, though less capable in

--- a/products/recipes/sdxl-with-refiner-comfyui.mdx
+++ b/products/recipes/sdxl-with-refiner-comfyui.mdx
@@ -2,7 +2,7 @@
 title: Stable Diffusion XL with Refiner - ComfyUI (API)
 ---
 
-_Last Updated: December 04, 2024_
+_Last Updated: March 25, 2025_
 
 <Tip>Deploy from the [SaladCloud Portal](https://portal.salad.com).</Tip>
 <Note>See the [Benchmark](https://blog.salad.com/sdxl-benchmark/) for performance information.</Note>
@@ -16,7 +16,7 @@ Stability AI. It includes the base and
 [ComfyUI](https://github.com/comfyanonymous/ComfyUI/), exposed via
 [a simple HTTP API](https://github.com/SaladTechnologies/comfyui-api) to facilitate scalable stateless operation. Users
 can make an HTTP request to the provided endpoints and get back one or more images in base64 encoded form. Optionally,
-users can receive completed images via a webhook.
+users can receive completed images via a webhook. **THIS RECIPE DOES NOT SERVE THE WEB UI**.
 
 Stable Diffusion XL is notable for a number of reasons:
 


### PR DESCRIPTION
There are some outdated references in the image gen documentation. Also added text to all the image gen recipes that specify we do not host the web ui.