### PR TITLE
Tutorial for Cuda 12.8 and pytorch

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -189,6 +189,7 @@
               "tutorials/high-performance-storage-solutions",
               "tutorials/jwt-authentication",
               "tutorials/performance-monitoring",
+              "tutorials/pytorch-rtx5090",
               {
                 "group": "Run a Node App",
                 "pages": [

--- a/products/sce/faqs.mdx
+++ b/products/sce/faqs.mdx
@@ -193,6 +193,8 @@ We are SOC 2 Type 1 compliant. You can read more about our compliance
 
 We have RTX 5090 GPUs on SaladCloud! There are some things you should know before deploying:
 
+<Tip>[Build your own compatible docker image](/tutorials/pytorch-rtx5090) for the RTX 5090 and RTX 5080.</Tip>
+
 - **MINIMUM CUDA VERSION: 12.8** - If your application does not use CUDA 12.8, it will not run on the RTX 5090.
 - As of March 17, 2025, **PyTorch has not released an official build** with support for CUDA 12.8. You can build PyTorch
   from source with CUDA 12.8 support, or use the "nightly" build.

--- a/products/sce/faqs.mdx
+++ b/products/sce/faqs.mdx
@@ -3,7 +3,7 @@ title: 'Salad Container Engine FAQs'
 sidebarTitle: 'FAQs'
 ---
 
-_Last Updated: March 17, 2025_
+_Last Updated: April 1, 2025_
 
 This document is a must-read before getting started with SaladCloud. Here, we detail what SaladCloud is, the nature of
 our network, how SaladCloud works, unique traits of our distributed network, the choice of consumer GPUs over data

--- a/tutorials/pytorch-rtx5090.mdx
+++ b/tutorials/pytorch-rtx5090.mdx
@@ -3,7 +3,7 @@ title: Running PyTorch on RTX 5090 and 5080 GPUs
 description: This tutorial provides a step-by-step guide to running PyTorch on the Nvidia RTX 50XX series GPUs
 ---
 
-_Last Updated: April 2, 2025_
+_Last Updated: April 1, 2025_
 
 ## Overview
 

--- a/tutorials/pytorch-rtx5090.mdx
+++ b/tutorials/pytorch-rtx5090.mdx
@@ -1,0 +1,73 @@
+---
+title: Running PyTorch on RTX 5090 and 5080 GPUs
+description: This tutorial provides a step-by-step guide to running PyTorch on the Nvidia RTX 50XX series GPUs
+---
+
+_Last Updated: April 2, 2025_
+
+## Overview
+
+Nvidia's new RTX 5090 and RTX 5080 GPUs require CUDA 12.8, but PyTorch official releases do not yet support it.
+[Check here in case this guide is out of date](https://hub.docker.com/r/pytorch/pytorch/tags).
+
+This tutorial provides a workaround to run PyTorch on the RTX 50-series GPUs using the latest nightly build of PyTorch.
+
+<Info>
+  If you intend to run a workload both on 50-series gpus and older 40- or 30-series gpus, you will need to maintain
+  separate docker images. As of the time of this writing, older GPUs do not have cuda 12.8 support, so the image you
+  have to build for the 50-series will not work on older GPUs.
+</Info>
+
+## Dockerfile
+
+This Dockerfile sets up a container with the necessary dependencies to run PyTorch on RTX 50-series GPUs.
+
+We start with the official nvidia/cuda image, using the "runtime" version of CUDA 12.8.1. There is also a "devel"
+version available. [See all tags.](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda/tags)
+
+From there, we set up our python environment, and install torch while setting `--index-url` to the nightly build of
+PyTorch, built for CUDA 12.8.
+
+```dockerfile
+FROM nvcr.io/nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update -y && apt install -y \
+    wget \
+    curl \
+    git \
+    python3 \
+    python3-pip \
+    python3-venv \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN . /opt/venv/bin/activate
+
+RUN pip install --upgrade pip
+RUN pip install --pre torch torchvision torchaudio \
+    --index-url https://download.pytorch.org/whl/nightly/cu128
+```
+
+## Build
+
+```bash
+docker build -t my-registry/pytorch:nightly-cuda12.8-cudnn9-runtime --push .
+```
+
+## Use
+
+Once you've built the image, you can use it in your dockerfile like any other pytorch base image
+
+```dockerfile
+# OLD: pytorch/pytorch:2.6.0-cuda12.6-cudnn8-runtime
+FROM my-registry/pytorch:nightly-cuda12.8-cudnn9-runtime
+
+# Do whatever you want here
+```
+
+## Conclusion
+
+That's all there is to it! Now you can run PyTorch on the RTX 50-series GPUs using the latest nightly build.


### PR DESCRIPTION
- Adds a tutorial on how to make a pytorch container that works with cuda 12.8, i.e. rtx 5090, 5080
- Verified this works by building a comfy image from it and running it on a 5090 successfully

https://salad-torch-nightly-50-series.mintlify.app/tutorials/pytorch-rtx5090