### PR TITLE
Rename reference tab to API reference

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -361,10 +361,10 @@
         ]
       },
       {
-        "tab": "Reference",
+        "tab": "API Reference",
         "groups": [
           {
-            "group": "Reference",
+            "group": "API Reference",
             "pages": [
               "reference/api-usage",
               {


### PR DESCRIPTION
We received feedback that finding our api docs was not intuitive, since none of the main tabs contain the word "api". That has been fixed.
![image](https://github.com/user-attachments/assets/fb208101-bfbe-45cf-a350-d21bdf649bee)
