### PR TITLE
Cuda12.8

### DIFF
--- a/products/sce/faqs.mdx
+++ b/products/sce/faqs.mdx
@@ -89,11 +89,11 @@ SaladCloud has three product lines:
 
 We have RTX 5090 GPUs on SaladCloud! There are some things you should know before deploying:
 
-<Tip>[Build your own compatible docker image](/tutorials/pytorch-rtx5090) for the RTX 5090 and RTX 5080.</Tip>
-
-- **MINIMUM CUDA VERSION: 12.8** - If your application does not use CUDA 12.8, it will not run on the RTX 5090.
-- As of March 17, 2025, **PyTorch has not released an official build** with support for CUDA 12.8. You can build PyTorch
-  from source with CUDA 12.8 support, or use the "nightly" build.
+- **MINIMUM CUDA VERSION: 12.8** - If your application does not use CUDA 12.8 or later, it will not run on the RTX 5090.
+- **CUDA 12.8 is not currently compatible with older GPUs** (Apr 24, 2025)- If you are using a docker image that is
+  compatible with the RTX 5090, it will not work on older GPUs. You will need to maintain separate docker images for the
+  RTX 5090 and older GPUs.
+- [More Info](/tutorials/pytorch-rtx5090.mdx)
 
 ## Security and Compliance
 

--- a/products/sce/faqs.mdx
+++ b/products/sce/faqs.mdx
@@ -3,7 +3,7 @@ title: 'Salad Container Engine FAQs'
 sidebarTitle: 'FAQs'
 ---
 
-_Last Updated: April 10, 2025_
+_Last Updated: April 24, 2025_
 
 This document is a must-read before getting started with SaladCloud. Here, we detail what SaladCloud is, the nature of
 our network, how SaladCloud works, unique traits of our distributed network, the choice of consumer GPUs over data

--- a/products/sce/faqs.mdx
+++ b/products/sce/faqs.mdx
@@ -93,7 +93,7 @@ We have RTX 5090 GPUs on SaladCloud! There are some things you should know befor
 - **CUDA 12.8 is not currently compatible with older GPUs** (Apr 24, 2025)- If you are using a docker image that is
   compatible with the RTX 5090, it will not work on older GPUs. You will need to maintain separate docker images for the
   RTX 5090 and older GPUs.
-- [More Info](/tutorials/pytorch-rtx5090.mdx)
+- [More Info](/tutorials/pytorch-rtx5090)
 
 ## Security and Compliance
 

--- a/tutorials/pytorch-rtx5090.mdx
+++ b/tutorials/pytorch-rtx5090.mdx
@@ -14,8 +14,6 @@ Nvidia's new RTX 5090 and RTX 5080 GPUs require CUDA 12.8. As of April 24, 2025,
 - [pytorch/pytorch:2.7.0-cuda12.8-cudnn9-runtime](https://hub.docker.com/layers/pytorch/pytorch/2.7.0-cuda12.8-cudnn9-runtime/images/sha256-7db0e1bf4b1ac274ea09cf6358ab516f8a5c7d3d0e02311bed445f7e236a5d80)
 - [pytorch/pytorch:2.7.0-cuda12.8-cudnn9-devel](https://hub.docker.com/layers/pytorch/pytorch/2.7.0-cuda12.8-cudnn9-devel/images/sha256-e97058f7b9b583517643477cc9a0433e54594038efd85ec4abd7836233d626f3)
 
-This tutorial provides a workaround to run PyTorch on the RTX 50-series GPUs using the latest nightly build of PyTorch.
-
 <Info>
   If you intend to run a workload both on 50-series gpus and older 40- or 30-series gpus, you will need to maintain
   separate docker images. As of the time of this writing, older GPUs and their drivers do not have cuda 12.8 support, so

--- a/tutorials/pytorch-rtx5090.mdx
+++ b/tutorials/pytorch-rtx5090.mdx
@@ -1,6 +1,6 @@
 ---
 title: Running PyTorch on RTX 5090 and 5080 GPUs
-description: This tutorial provides a step-by-step guide to running PyTorch on the Nvidia RTX 50XX series GPUs
+description: Use pytorch 2.7 with CUDA 12.8 on RTX 5090 and 5080 GPUs
 ---
 
 _Last Updated: April 24, 2025_

--- a/tutorials/pytorch-rtx5090.mdx
+++ b/tutorials/pytorch-rtx5090.mdx
@@ -3,71 +3,21 @@ title: Running PyTorch on RTX 5090 and 5080 GPUs
 description: This tutorial provides a step-by-step guide to running PyTorch on the Nvidia RTX 50XX series GPUs
 ---
 
-_Last Updated: April 1, 2025_
+_Last Updated: April 24, 2025_
 
 ## Overview
 
-Nvidia's new RTX 5090 and RTX 5080 GPUs require CUDA 12.8, but PyTorch official releases do not yet support it.
-[Check here in case this guide is out of date](https://hub.docker.com/r/pytorch/pytorch/tags).
+Nvidia's new RTX 5090 and RTX 5080 GPUs require CUDA 12.8. As of April 24, 2025, the latest stable release of PyTorch
+(2.7.0) supports this, and you should find success with the
+[official pytorch docker images](https://hub.docker.com/r/pytorch/pytorch) for CUDA 12.8.
+
+- [pytorch/pytorch:2.7.0-cuda12.8-cudnn9-runtime](https://hub.docker.com/layers/pytorch/pytorch/2.7.0-cuda12.8-cudnn9-runtime/images/sha256-7db0e1bf4b1ac274ea09cf6358ab516f8a5c7d3d0e02311bed445f7e236a5d80)
+- [pytorch/pytorch:2.7.0-cuda12.8-cudnn9-devel](https://hub.docker.com/layers/pytorch/pytorch/2.7.0-cuda12.8-cudnn9-devel/images/sha256-e97058f7b9b583517643477cc9a0433e54594038efd85ec4abd7836233d626f3)
 
 This tutorial provides a workaround to run PyTorch on the RTX 50-series GPUs using the latest nightly build of PyTorch.
 
 <Info>
   If you intend to run a workload both on 50-series gpus and older 40- or 30-series gpus, you will need to maintain
-  separate docker images. As of the time of this writing, older GPUs do not have cuda 12.8 support, so the image you
-  have to build for the 50-series will not work on older GPUs.
+  separate docker images. As of the time of this writing, older GPUs and their drivers do not have cuda 12.8 support, so
+  the image you have to build for the 50-series will not work on older GPUs.
 </Info>
-
-## Dockerfile
-
-This Dockerfile sets up a container with the necessary dependencies to run PyTorch on RTX 50-series GPUs.
-
-We start with the official nvidia/cuda image, using the "runtime" version of CUDA 12.8.1. There is also a "devel"
-version available. [See all tags.](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda/tags)
-
-From there, we set up our python environment, and install torch while setting `--index-url` to the nightly build of
-PyTorch, built for CUDA 12.8.
-
-```dockerfile
-FROM nvcr.io/nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt update -y && apt install -y \
-    wget \
-    curl \
-    git \
-    python3 \
-    python3-pip \
-    python3-venv \
-    unzip \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN python3 -m venv /opt/venv
-ENV PATH="/opt/venv/bin:$PATH"
-RUN . /opt/venv/bin/activate
-
-RUN pip install --upgrade pip
-RUN pip install --pre torch torchvision torchaudio \
-    --index-url https://download.pytorch.org/whl/nightly/cu128
-```
-
-## Build
-
-```bash
-docker build -t my-registry/pytorch:nightly-cuda12.8-cudnn9-runtime --push .
-```
-
-## Use
-
-Once you've built the image, you can use it in your dockerfile like any other pytorch base image
-
-```dockerfile
-# OLD: pytorch/pytorch:2.6.0-cuda12.6-cudnn8-runtime
-FROM my-registry/pytorch:nightly-cuda12.8-cudnn9-runtime
-
-# Do whatever you want here
-```
-
-## Conclusion
-
-That's all there is to it! Now you can run PyTorch on the RTX 50-series GPUs using the latest nightly build.


### PR DESCRIPTION
Pytorch 2.7 has support for blackwell chips / cuda 12.8 now, and there are official pytorch images available. Therefore, we no longer recommend users build their own docker image with the nightly build