### PR TITLE
update language codes for transcription api

### DIFF
--- a/api-specs/transcribe.json
+++ b/api-specs/transcribe.json
@@ -3087,7 +3087,18 @@
           "language_code": {
             "type": "string",
             "description": "Language code for the transcription. Defaults to 'en' (English).",
-            "example": "en"
+            "example": "en",
+            "enum": [
+              "en", "zh", "de", "es", "ru", "ko", "fr", "ja", "pt", "tr", "pl", "ca",
+              "nl", "ar", "sv", "it", "id", "hi", "fi", "vi", "he", "uk", "el", "ms",
+              "cs", "ro", "da", "hu", "ta", "no", "th", "ur", "hr", "bg", "lt", "la",
+              "mi", "ml", "cy", "sk", "te", "fa", "lv", "bn", "sr", "az", "sl", "kn",
+              "et", "mk", "br", "eu", "is", "hy", "ne", "mn", "bs", "kk", "sq", "sw",
+              "gl", "mr", "pa", "si", "km", "sn", "yo", "so", "af", "oc", "ka", "be",
+              "tg", "sd", "gu", "am", "yi", "lo", "uz", "fo", "ht", "ps", "tk", "nn",
+              "mt", "sa", "lb", "my", "bo", "tl", "mg", "as", "tt", "haw", "ln", "ha",
+              "ba", "jw", "su", "yue"
+            ]
           },
           "return_as_file": {
             "type": "boolean",

--- a/guides/transcription/salad-transcription-api/speech-to-text.mdx
+++ b/guides/transcription/salad-transcription-api/speech-to-text.mdx
@@ -245,9 +245,12 @@ language. However, specifying the language correctly enhances transcription accu
 specified, the system will return a **translation** to the specified language. For **multilingual audio** content, it is
 recommended not to specify a language to achieve optimal results.
 
+Accuracy varies by language. For tested results, see our
+[accuracy benchmarks](/products/transcription/accuracy-benchmarks).
+
 #### Usage
 
-Set `"language_code": language_code` to specify the language of the audio content.
+Set the `language_code` to the **ISO 639-1** code of the audio's language.
 
 **Example:**
 
@@ -258,16 +261,44 @@ Set `"language_code": language_code` to specify the language of the audio conten
 }
 ```
 
-**Supported Languages:** Below is a list of supported language codes: English, Chinese, German, Spanish, Russian,
-Korean, French, Japanese, Portuguese, Turkish, Polish, Catalan, Dutch, Arabic, Swedish, Italian, Indonesian, Hindi,
-Finnish, Vietnamese, Hebrew, Ukrainian, Greek, Malay, Czech, Romanian, Danish, Hungarian, Tamil, Norwegian, Thai, Urdu,
-Croatian, Bulgarian, Lithuanian, Latin, Maori, Malayalam, Welsh, Slovak, Telugu, Persian, Latvian, Bengali, Serbian,
-Azerbaijani, Slovenian, Kannada, Estonian, Macedonian, Breton, Basque, Icelandic, Armenian, Nepali, Mongolian, Bosnian,
-Kazakh, Albanian, Swahili, Galician, Marathi, Punjabi, Sinhala, Khmer, Shona, Yoruba, Somali, Afrikaans, Occitan,
-Georgian, Belarusian, Tajik, Sindhi, Gujarati, Amharic, Yiddish, Lao, Uzbek, Faroese, Haitian Creole, Pashto, Turkmen,
-Nynorsk, Maltese, Sanskrit, Luxembourgish, Myanmar, Tibetan, Tagalog, Malagasy, Assamese, Tatar, Hawaiian, Lingala,
-Hausa, Bashkir, Javanese, Sundanese, Cantonese, Burmese, Valencian, Flemish, Haitian, Letzeburgesch, Pushto, Panjabi,
-Moldavian, Moldovan, Sinhalese, Castilian, Mandarin.
+**Supported Language Codes (ISO 639-1):**
+
+| Code | Language    | Code | Language   | Code | Language       |
+| ---- | ----------- | ---- | ---------- | ---- | -------------- |
+| en   | English     | zh   | Chinese    | de   | German         |
+| es   | Spanish     | ru   | Russian    | ko   | Korean         |
+| fr   | French      | ja   | Japanese   | pt   | Portuguese     |
+| tr   | Turkish     | pl   | Polish     | ca   | Catalan        |
+| nl   | Dutch       | ar   | Arabic     | sv   | Swedish        |
+| it   | Italian     | id   | Indonesian | hi   | Hindi          |
+| fi   | Finnish     | vi   | Vietnamese | he   | Hebrew         |
+| uk   | Ukrainian   | el   | Greek      | ms   | Malay          |
+| cs   | Czech       | ro   | Romanian   | da   | Danish         |
+| hu   | Hungarian   | ta   | Tamil      | no   | Norwegian      |
+| th   | Thai        | ur   | Urdu       | hr   | Croatian       |
+| bg   | Bulgarian   | lt   | Lithuanian | la   | Latin          |
+| mi   | Maori       | ml   | Malayalam  | cy   | Welsh          |
+| sk   | Slovak      | te   | Telugu     | fa   | Persian        |
+| lv   | Latvian     | bn   | Bengali    | sr   | Serbian        |
+| az   | Azerbaijani | sl   | Slovenian  | kn   | Kannada        |
+| et   | Estonian    | mk   | Macedonian | br   | Breton         |
+| eu   | Basque      | is   | Icelandic  | hy   | Armenian       |
+| ne   | Nepali      | mn   | Mongolian  | bs   | Bosnian        |
+| kk   | Kazakh      | sq   | Albanian   | sw   | Swahili        |
+| gl   | Galician    | mr   | Marathi    | pa   | Punjabi        |
+| si   | Sinhala     | km   | Khmer      | sn   | Shona          |
+| yo   | Yoruba      | so   | Somali     | af   | Afrikaans      |
+| oc   | Occitan     | ka   | Georgian   | be   | Belarusian     |
+| tg   | Tajik       | sd   | Sindhi     | gu   | Gujarati       |
+| am   | Amharic     | yi   | Yiddish    | lo   | Lao            |
+| uz   | Uzbek       | fo   | Faroese    | ht   | Haitian Creole |
+| ps   | Pashto      | tk   | Turkmen    | nn   | Nynorsk        |
+| mt   | Maltese     | sa   | Sanskrit   | lb   | Luxembourgish  |
+| my   | Myanmar     | bo   | Tibetan    | tl   | Tagalog        |
+| mg   | Malagasy    | as   | Assamese   | tt   | Tatar          |
+| haw  | Hawaiian    | ln   | Lingala    | ha   | Hausa          |
+| ba   | Bashkir     | jw   | Javanese   | su   | Sundanese      |
+| yue  | Cantonese   |      |            |      |                |
 
 ### Note
 

--- a/guides/transcription/salad-transcription-api/transcription-quick-start.mdx
+++ b/guides/transcription/salad-transcription-api/transcription-quick-start.mdx
@@ -162,8 +162,10 @@ false.
 
 #### “language_code”
 
-Transcription is available in 97 languages. We automatically identify the source language. “language_code” need to be
-specified only if diarization is required.
+Transcription is available in 97 languages. We automatically identify the source language. You only need to specify the
+"language_code" if diarization is required. Please note that accuracy varies across languages — some may perform better
+than others. For detailed accuracy information, refer to our
+[language benchmark results](/products/transcription/accuracy-benchmarks).
 
 #### “sentence_level_timestamps”
 


### PR DESCRIPTION
A few pages updated to add language codes supported. (Fireflies feedback):

API Reference: 
![image](https://github.com/user-attachments/assets/34b118fb-9bde-490c-9592-3d71def38528)

Quick start page. Added a line about accuracy benchmaks:
![image](https://github.com/user-attachments/assets/22760f74-1b09-49b9-9369-1fb2fc93d9c4)

Speech to text page: 
![image](https://github.com/user-attachments/assets/bc745643-176c-482c-bb22-05c28b30bf76)
![image](https://github.com/user-attachments/assets/e92a1a58-ce0d-4517-ba6d-6bf7c8c3c7f2)
 

