### PR TITLE
Fix name of docs file in docs.json

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -304,7 +304,7 @@
                   "container-engine/reference/recipes/gromacs-srcg",
                   "container-engine/reference/recipes/kuzco",
                   "container-engine/reference/recipes/ollama",
-                  "container-engine/reference/recipes/opemm-srcg",
+                  "container-engine/reference/recipes/openmm-srcg",
                   "container-engine/reference/recipes/quai",
                   "container-engine/reference/recipes/sogni-fast-worker",
                   "container-engine/reference/recipes/tgi",


### PR DESCRIPTION
Simple fix to docs.json for typo