### PR TITLE
Amd recipe update

### DIFF
--- a/container-engine/explanation/core-concepts/architectural-overview.mdx
+++ b/container-engine/explanation/core-concepts/architectural-overview.mdx
@@ -4,7 +4,7 @@ description: The world's largest distributed GPU cloud at the most competitive p
 sidebarTitle: 'Distributed Architecture'
 ---
 
-_Last Updated: May 29, 2025_
+_Last Updated: July 13, 2026_
 
 <iframe
   src="https://player.vimeo.com/video/1088518526?transparent=0"
@@ -33,10 +33,11 @@ with distribution roughly following population density patterns.
 
 **Hardware Diversity:**
 
-- GPU types range from older GTX series GPUs to mid-range RTX 3060s (available in 98 countries) to high-end RTX 4090s
-  (concentrated in 63 countries, primarily US, Canada, and UK)
-- Each node is equipped with consumer GPUs and varying CPU and memory configurations
-- Maximum node configuration: 16 vCPUs, 60 GB RAM, RTX 5090 with 32 GB VRAM
+- SaladCloud offers selected NVIDIA and AMD GPU classes. Retrieve the current inventory with the
+  [List GPU Classes API](/reference/saladcloud-api/organizations/list-gpu-classes).
+- Nodes have varying GPU, CPU, and memory configurations.
+- GPU availability varies by class, region, priority, and the nodes currently participating in the network. Check the
+  [GPU Availability API](/reference/saladcloud-api/organizations/get-gpu-availability) before large deployments.
 - Up to 250 GB of ephemeral storage available while instances are running
 
 **Network Characteristics:**

--- a/container-engine/explanation/core-concepts/faqs.mdx
+++ b/container-engine/explanation/core-concepts/faqs.mdx
@@ -3,7 +3,7 @@ title: 'Salad Container Engine FAQs'
 sidebarTitle: 'FAQs'
 ---
 
-_Last Updated: April 24, 2025_
+_Last Updated: July 13, 2026_
 
 This document is a must-read before getting started with SaladCloud. Here, we detail what SaladCloud is, the nature of
 our network, how SaladCloud works, unique traits of our distributed network, the choice of consumer GPUs over data
@@ -30,8 +30,13 @@ significant compute and everyday, 11,000+ GPUs are active on the network.
 
 ### What kind of GPUs does SaladCloud have?
 
-All GPUs on SaladCloud belong to the RTX/GTX class of GPUs from Nvidia. Our GPU selection policy is strict and we only
-onboard AI-enabled, high performance compute capable GPUs to the network.
+SaladCloud offers selected NVIDIA and AMD GPU classes. Use the
+[List GPU Classes API](/reference/saladcloud-api/organizations/list-gpu-classes) to retrieve the current classes and IDs
+available to your organization.
+
+NVIDIA compute images generally use CUDA, while AMD compute images generally use ROCm and HIP. An application or image
+is not automatically compatible with both vendors. See [AMD GPUs and ROCm](/container-engine/reference/amd-gpus) for
+image-selection and validation guidance.
 
 ### How does SaladCloud work?
 
@@ -50,10 +55,11 @@ per month on SaladCloud as a reward that they exchange for games, gift cards and
 - Since SaladCloud is a compute-share network, our GPUs have longer cold start times than usual, and are subject to
   interruption.
 
-- We only have RTX/GTX class of GPUs from Nvidia. Our thesis is that most AI/ML production workloads get better
-  cost-performance on consumer-grade GPUs. See our [benchmarks](https://blog.salad.com/) for more information.
+- The network includes selected NVIDIA and AMD GPU classes. Use the
+  [List GPU Classes API](/reference/saladcloud-api/organizations/list-gpu-classes) for the current inventory, and match
+  your container image to the selected GPU vendor and architecture.
 
-- The highest vRAM on the network is 32 GB.
+- GPU VRAM varies by class. The highest vRAM on the network is 32 GB.
 
 - Workloads requiring extremely low latency times are not a fit for our network.
 

--- a/container-engine/explanation/infrastructure-platform/liveness-probes.mdx
+++ b/container-engine/explanation/infrastructure-platform/liveness-probes.mdx
@@ -2,14 +2,15 @@
 title: 'Liveness Probes'
 ---
 
-_Last Updated: October 15, 2024_
+_Last Updated: July 13, 2026_
 
 # Overview
 
 Liveness probes are similar to startup probes, except that they run after the startup probe has completed successfully.
 Typically, Liveness probes are used to evaluate whether the application running in your container is in a healthy state.
 If a container's liveness probe reaches the failure state, the container will be reallocated to a different node.
-Liveness probes are a good place to put logic that checks for CUDA errors, and other unrecoverable states.
+Liveness probes are a good place to check for unrecoverable application and GPU runtime errors, including CUDA errors in
+NVIDIA workloads or ROCm/HIP errors in AMD workloads.
 
 ## Successful Liveness Probe
 

--- a/container-engine/explanation/job-processing/long-running-tasks.mdx
+++ b/container-engine/explanation/job-processing/long-running-tasks.mdx
@@ -4,7 +4,7 @@ description: 'Performing Long-Running Tasks on SaladCloud'
 sidebarTitle: 'Long-Running Tasks'
 ---
 
-_Last Updated: January 20, 2025_
+_Last Updated: July 13, 2026_
 
 There are
 [two primary methods](/container-engine/explanation/core-concepts/architectural-overview#provide-input-to-applications)
@@ -53,7 +53,7 @@ throughput and optimize resource utilization for these types of jobs.
 While leveraging CPU and I/O capacity effectively, multiprocessing or multithreading-based concurrent inference over a
 single GPU might limit optimal GPU cache utilization and degrade performance, due to each inference running in isolation
 at its own layer or stage. Additionally, the multiprocessing approach can increase VRAM consumption, as each process
-requires a separate CUDA context and loads its own model into the GPU VRAM.
+creates a separate GPU runtime context and loads its own model into GPU VRAM.
 
 The recommendation is to use a multi-pipeline, staged architecture, where GPU inference remains sequential or batched by
 a separated process or thread, while other tasks run in parallel or asynchronously across one or more processes or

--- a/container-engine/explanation/job-processing/long-running-tasks.mdx
+++ b/container-engine/explanation/job-processing/long-running-tasks.mdx
@@ -43,7 +43,7 @@ fully completed before the next one begins.
 <img src="/container-engine/images/lrt-so1.png" />
 
 The lifecycle of job execution may involve multiple stages, including downloading the input, pre-processing (e.g.,
-format conversion, re-samping and chunking), executing GPU inference, post-processing (e.g., merging and summarizing),
+format conversion, resampling and chunking), executing GPU inference, post-processing (e.g., merging and summarizing),
 uploading the output. Each stage has different resource demands—some are I/O-bound, others are CPU-intensive, and some
 are GPU-intensive.
 

--- a/container-engine/how-to-guides/troubleshooting.mdx
+++ b/container-engine/how-to-guides/troubleshooting.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Troubleshooting
 description: Troubleshooting common issues with Salad Container Engine workloads.
 ---
 
-_Last Updated: February 5, 2026_
+_Last Updated: July 13, 2026_
 
 The following guide addresses common issues encountered when running container workloads on Salad. These solutions will
 help resolve frequent problems with downloads, container failures, networking, and access. If issues persist after
@@ -76,7 +76,7 @@ repeated start failures typically indicate a problem with the container image or
 
 - Invalid or missing container entrypoint
 - Image built for an incompatible architecture
-- GPU images with missing or incompatible CUDA libraries
+- GPU images with missing or incompatible CUDA or ROCm/HIP libraries
 
 #### Command and Argument Errors
 
@@ -88,7 +88,9 @@ repeated start failures typically indicate a problem with the container image or
 
 - Using a non-GPU container image with a GPU container group
 - Using a GPU-dependent image in a CPU-only container group
-- CUDA version incompatibility between the image and host drivers
+- Using a CUDA image with an AMD GPU class
+- Using a ROCm image with an NVIDIA GPU class
+- An incompatibility between the image's GPU runtime, the host driver, the GPU architecture, and the application build
 
 ### Debugging Start Failures
 
@@ -99,6 +101,21 @@ To systematically debug start failures:
 3. Start the container with a minimal long-running command such as `sleep infinity` and connect via the terminal in the
    Portal or with SSH. Once connected, manually verify that the expected files, binaries, and environment variables are
    present and correct. Also verify that the intended entrypoint or command run successfully.
+
+### GPU Compatibility Checks
+
+First, confirm the vendor of every GPU class selected for the container group. A vendor-specific image should select
+classes from only that vendor:
+
+- NVIDIA workloads need a compatible CUDA image.
+- AMD workloads need a compatible ROCm image built for the selected GPU architecture. See
+  [AMD GPUs and ROCm](/container-engine/reference/amd-gpus).
+
+Inside a running replica, use diagnostics supplied by the image:
+
+- **NVIDIA:** Run `nvidia-smi` and inspect the application logs for CUDA, cuDNN, NCCL, or kernel compatibility errors.
+- **AMD:** If the image includes them, run `rocminfo` and `amd-smi list`, and inspect the application logs for ROCm,
+  HIP, or `gfx` compatibility errors.
 
 ## My Container Group Is Stuck Downloading / Stuck at Downloading 99%
 

--- a/container-engine/reference/amd-gpus.mdx
+++ b/container-engine/reference/amd-gpus.mdx
@@ -1,0 +1,271 @@
+---
+title: AMD GPUs and ROCm
+sidebarTitle: AMD GPUs
+description: Select AMD GPU classes and run ROCm-compatible containers on SaladCloud.
+---
+
+_Last Updated: July 13, 2026_
+
+## Overview
+
+SaladCloud supports selected AMD GPU classes in addition to NVIDIA GPU classes. AMD compute workloads generally use
+[ROCm](https://rocm.docs.amd.com/) and HIP, while NVIDIA compute workloads generally use CUDA.
+
+Running successfully on an AMD GPU requires a compatible combination of:
+
+1. The AMD GPU class selected in SaladCloud.
+2. The ROCm user-space libraries and framework in the container image.
+3. The compiled kernels, model features, precision, and quantization used by the application.
+
+GPU access alone does not make an image portable between vendors. A CUDA-only image is for NVIDIA GPUs, and a
+ROCm-specific image is for AMD GPUs unless that exact image has been built and tested for both.
+
+## SaladCloud and ROCm Responsibilities
+
+The boundary between SaladCloud and the container image is important when adapting instructions written for a local AMD
+machine.
+
+| Area                   | SaladCloud-specific                                                                             | AMD/ROCm-specific                                                                                                          |
+| ---------------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| GPU selection          | You select GPU class IDs and priority in the Portal or through API.                             | The image and application must support the selected GPU's `gfx` architecture.                                              |
+| Host and device access | SaladCloud allocates the node and GPU. You do not configure the host from inside the container. | ROCm depends on an AMD host driver and compatible user-space libraries. Your image supplies the user-space stack.          |
+| Container image        | SaladCloud pulls and runs the image you configure.                                              | The image must contain ROCm-enabled frameworks, libraries, compiled extensions, and any diagnostic utilities you need.     |
+| Diagnostics            | Use the web terminal, Container Logs, and System Events to inspect a replica.                   | Tools such as `rocminfo` and `amd-smi` report AMD runtime and device information only when they are included in the image. |
+| Resilience             | Nodes are distributed and instances can be reallocated.                                         | Validate the exact software stack on every AMD class you select and repeat validation after reallocation.                  |
+
+## Recommended Deployment Path
+
+Use this progression for a new AMD workload:
+
+1. Retrieve the AMD classes available from the Portal or
+   [List GPU Classes API](/reference/saladcloud-api/organizations/list-gpu-classes).
+2. Check estimated capacity with the
+   [GPU Availability API](/reference/saladcloud-api/organizations/get-gpu-availability).
+3. Start with one AMD class and one replica to keep the first test easy to diagnose.
+4. Use a versioned ROCm image tag or image digest that is compatible with that class. Do not use `latest` as a
+   production pin.
+5. Verify device discovery, the framework backend, and a real GPU operation.
+6. Test the actual model and feature path, including its precision, quantization, and compiled extensions.
+7. Record the class, image digest, `gfx` target, software versions, configuration, and results.
+8. Test multiple separately allocated replicas and a reallocation before scaling the workload.
+9. Add another AMD class only after the same image and workload pass on that class too.
+
+Treat the selected Salad class, pinned image, and application configuration as one tested unit. Changing any one of them
+requires revalidation.
+
+## Choose AMD GPU Classes
+
+Use the SaladCloud Portal or the [List GPU Classes API](/reference/saladcloud-api/organizations/list-gpu-classes) to
+find the classes available. Use the returned class IDs rather than copying a UUID from an unrelated example.
+
+Inventory, pricing, priority options, organization access, and capacity can change. Use the Portal and APIs for the
+values currently available to your organization instead of relying on a static table in this page.
+
+Before a large deployment, query the
+[GPU Availability API](/reference/saladcloud-api/organizations/get-gpu-availability) with the class IDs and CPU, memory,
+storage, and country requirements you intend to deploy. Availability is an estimate and can change as nodes enter and
+leave the distributed network.
+
+### Start with a Narrow Hardware Selection
+
+For initial validation, select a single AMD class. When a container group includes multiple classes, an instance can be
+allocated from any selected class, so the image must support the `gfx` target and application features required on all
+of them.
+
+Use separate container groups when classes require different images, build targets, or application settings. Separate
+groups also make capacity planning, canary deployments, and rollback easier to reason about.
+
+Do not combine AMD and NVIDIA classes for a vendor-specific image. Even when an application has both CUDA and ROCm
+builds, keep the vendor-specific artifacts and validation records separate unless the exact multi-vendor image has
+passed on every selected class.
+
+## Choose or Build a Compatible Image
+
+ROCm compatibility is a chain:
+
+`Salad GPU class` → `host driver and device access` → `ROCm user space` → `framework and libraries` →
+`application kernels and features`
+
+A mismatch at any layer can allow the container to start while a framework import, kernel launch, or specific model
+feature still fails.
+
+### Image Best Practices
+
+- Prefer a versioned, AMD-published framework image as a starting point when one fits the workload. AMD validation is
+  useful upstream evidence, but it does not prove that the image and application have passed on a Salad GPU class.
+- Pin the tested image by digest where practical. Otherwise, use a version-specific tag and record the resolved digest.
+- Check AMD's current
+  [ROCm compatibility matrix](https://rocm.docs.amd.com/en/latest/compatibility/compatibility-matrix.html) and the
+  framework's compatibility documentation.
+- Confirm that the framework and every compiled extension contain code for the selected `gfx` target. If one image will
+  serve multiple AMD classes, build and test every required target.
+- Include `rocminfo`, AMD SMI, and profiling tools in a diagnostic image or production image when you need them. GPU
+  selection does not add missing executables to the container.
+- Provide ROCm user-space libraries in the image. Do not attempt to install or replace the host kernel driver from the
+  container.
+- Install application dependencies and compile extensions while building the image instead of at replica startup.
+  Smaller, reproducible runtime images reduce download and initialization work on newly allocated nodes.
+- Test the real workload. Successful device enumeration or a framework import is only a smoke test.
+
+AMD publishes a separate
+[user-space and AMD GPU driver compatibility matrix](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/user-kernel-space-compat-matrix.html).
+Use it when diagnosing compatibility.
+
+## Local Docker Instructions Versus SaladCloud
+
+AMD's local Docker documentation shows host options such as `--device /dev/kfd`, `--device /dev/dri`,
+`--group-add video`, and `--security-opt`. Those options configure a Docker host that you administer. They are not
+container-group settings to copy into SaladCloud.
+
+On SaladCloud, select an AMD class in the container's
+[resource requirements](/container-engine/explanation/container-groups/container-groups#container-group-components).
+SaladCloud handles the host and GPU allocation. Configure only the container-level resources and settings exposed by the
+Portal or API.
+
+## Validate the Deployed Combination
+
+Validate in layers so a failure identifies the boundary that needs attention:
+
+1. **Allocation:** Confirm that the replica reaches `Running` on the intended AMD class. Review
+   [System Events](/container-engine/explanation/container-groups/system-events) if it repeatedly exits or reallocates.
+2. **Device discovery:** If the image includes them, use the read-only `rocminfo` and `amd-smi list` diagnostics to
+   confirm that the expected AMD device is visible.
+3. **Framework backend:** Confirm that the installed framework is a ROCm build and reports a usable GPU.
+4. **GPU execution:** Run a real tensor or kernel operation and synchronize it so asynchronous errors surface.
+5. **Application path:** Exercise the actual model, precision, quantization, attention backend, custom operators, and
+   input sizes used in production.
+6. **Distributed operation:** Repeat the checks on separately allocated replicas and after reallocation.
+
+## PyTorch on ROCm
+
+PyTorch intentionally reuses its `torch.cuda` API namespace on ROCm. A ROCm build therefore still uses device strings
+such as `cuda` and calls such as `torch.cuda.is_available()`.
+
+`torch.cuda.is_available()` alone does not distinguish ROCm from CUDA. Check `torch.version.hip` and
+`torch.version.cuda` together:
+
+```python
+import torch
+
+print("PyTorch:", torch.__version__)
+print("ROCm/HIP:", torch.version.hip)
+print("CUDA:", torch.version.cuda)
+print("GPU available:", torch.cuda.is_available())
+print("GPU count:", torch.cuda.device_count())
+
+if torch.cuda.is_available():
+    print("GPU:", torch.cuda.get_device_name(0))
+```
+
+For a ROCm build, `torch.version.hip` is populated and `torch.version.cuda` is normally `None`. After this backend
+check, run a real tensor operation and call `torch.cuda.synchronize()`; see the
+[PyTorch AMD/ROCm tutorial](/container-engine/tutorials/machine-learning/pytorch-amd-rocm) for an example.
+
+## Production Best Practices
+
+### Make GPU Readiness Part of Application Readiness
+
+Do not mark a replica ready merely because its process has started. Load the model, initialize the ROCm-backed
+framework, and complete a representative GPU operation before the startup or readiness check succeeds. See
+[Startup Probes](/container-engine/explanation/infrastructure-platform/startup-probes) and
+[Health Probes](/container-engine/explanation/infrastructure-platform/health-probes).
+
+### Design for Reallocation
+
+Run multiple replicas for services that need continuous coverage. Keep model and state data outside ephemeral container
+storage, make initialization repeatable, and rerun the compatibility check when a replica is allocated to a replacement
+node.
+
+### Leave Resource Headroom
+
+Test with production input sizes and leave headroom in GPU memory, system memory, and storage. Framework initialization,
+compiled kernels, model caches, and peak input sizes can consume more memory than a small smoke test. Treat
+out-of-memory behavior and sustained throughput as application-level acceptance criteria.
+
+### Profile Before Tuning
+
+Establish a latency, throughput, and memory baseline before changing ROCm or framework settings. Use application-level
+profiling or AMD tools such as `rocprofv3` when they are included in the image, then re-profile to confirm that a change
+actually improves the workload.
+
+### Use Read-Only Telemetry
+
+Use `amd-smi` for interactive, read-only inspection when it is available in the image. For a production telemetry
+integration, prefer the AMD SMI Python or C++ library over parsing CLI output, and record the AMD SMI version used by
+the collector. Do not design a Salad workload around host-management operations such as GPU reset, clock, or power
+changes.
+
+### Roll Out Changes as New Compatibility Sets
+
+Canary a new image, framework, model build, or AMD class before expanding replicas. Keep the previous digest and
+configuration available for rollback, and store the new validation result alongside the image source.
+
+## Troubleshooting
+
+### The Replica Repeatedly Exits or Reallocates
+
+Check Container Logs and System Events before changing the ROCm stack. Confirm the image entrypoint, required CPU and
+memory, selected GPU vendor, and application exit code. A failure before ROCm initializes may be an ordinary container
+configuration problem.
+
+### The Image and GPU Vendors Do Not Match
+
+A CUDA-only image cannot use an AMD GPU through ROCm, and a ROCm-only image is not a CUDA image. Select only AMD classes
+for the ROCm artifact and only NVIDIA classes for the CUDA artifact.
+
+### No AMD Device Is Visible
+
+Confirm that the replica received the intended AMD class. Also inspect `ROCR_VISIBLE_DEVICES`, `HIP_VISIBLE_DEVICES`,
+and `CUDA_VISIBLE_DEVICES`; each can restrict which AMD devices a HIP application sees. If the device is still
+unavailable, collect the class ID/name, image digest, diagnostic output, Container Logs, and System Events for Salad
+support.
+
+### `torch.cuda.is_available()` Is `False`
+
+Check `torch.version.hip`. If it is `None`, the installed PyTorch build is not ROCm-enabled. If it is populated, check
+device visibility, the selected class, ROCm user-space compatibility, and compiled architecture support.
+
+### `hipErrorNoBinaryForGPU`
+
+This error means no compatible kernel image is available for the device. A dependency or custom extension might have
+been compiled for a different `gfx` target. Identify the target with `rocminfo`, rebuild all affected code for that
+target, and repeat the real-workload test on the same Salad class.
+
+### A Model Feature, Precision, or Quantization Fails
+
+Upstream ROCm support does not prove that every application feature works with every image and GPU architecture. Check
+the application's ROCm support and known issues, then validate the exact feature and configuration on the selected Salad
+class.
+
+### Performance Is Lower Than Expected
+
+Confirm that the application is using the GPU, run a warm-up, and measure the real workload. Inspect GPU utilization,
+memory use, CPU and I/O bottlenecks, input batching, and any runtime compilation. Compare results only after the same
+image and workload configuration have been tested across more than one allocation.
+
+### `AMD64` Appears in an Image or Binary Name
+
+`AMD64` is another name for the x86-64 CPU architecture. It does not indicate that an image includes ROCm or supports
+AMD GPUs.
+
+## Related SaladCloud Documentation
+
+- [List GPU Classes API](/reference/saladcloud-api/organizations/list-gpu-classes)
+- [GPU Availability API](/reference/saladcloud-api/organizations/get-gpu-availability)
+- [Container group resource selection](/container-engine/explanation/container-groups/container-groups#container-group-components)
+- [System Events](/container-engine/explanation/container-groups/system-events)
+- [Troubleshooting Salad Container Engine workloads](/container-engine/how-to-guides/troubleshooting)
+- [Run PyTorch on AMD GPUs with ROCm](/container-engine/tutorials/machine-learning/pytorch-amd-rocm)
+- [Build high-performance applications](/container-engine/tutorials/performance/high-performance-apps)
+
+## Related AMD and Framework Documentation
+
+- [AMD: Run ROCm Docker containers](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/docker.html)
+- [AMD: ROCm compatibility matrix](https://rocm.docs.amd.com/en/latest/compatibility/compatibility-matrix.html)
+- [AMD: User-space and AMD GPU driver compatibility](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/user-kernel-space-compat-matrix.html)
+- [AMD: PyTorch on ROCm installation](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/pytorch-install.html)
+- [AMD: PyTorch compatibility](https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/pytorch-compatibility.html)
+- [AMD: AMD SMI CLI](https://rocm.docs.amd.com/projects/amdsmi/en/latest/how-to/amdsmi-cli-tool.html)
+- [AMD: HIP environment variables](https://rocm.docs.amd.com/projects/HIP/en/latest/reference/env_variables.html)
+- [AMD: HIP performance guidelines](https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/performance_guidelines.html)
+- [PyTorch: HIP semantics](https://docs.pytorch.org/docs/stable/notes/hip.html)

--- a/container-engine/reference/amd-gpus.mdx
+++ b/container-engine/reference/amd-gpus.mdx
@@ -4,14 +4,15 @@ sidebarTitle: AMD GPUs
 description: Select AMD GPU classes and run ROCm-compatible containers on SaladCloud.
 ---
 
-_Last Updated: July 13, 2026_
+_Last Updated: July 14, 2026_
 
 ## Overview
 
 SaladCloud supports selected AMD GPU classes in addition to NVIDIA GPU classes. AMD compute workloads generally use
 [ROCm](https://rocm.docs.amd.com/) and HIP, while NVIDIA compute workloads generally use CUDA.
 
-Running successfully on an AMD GPU requires a compatible combination of:
+Salad Container Engine runs container instances inside WSL2. Running successfully on an AMD GPU requires a compatible
+combination of:
 
 1. The AMD GPU class selected in SaladCloud.
 2. The ROCm user-space libraries and framework in the container image.
@@ -25,13 +26,13 @@ ROCm-specific image is for AMD GPUs unless that exact image has been built and t
 The boundary between SaladCloud and the container image is important when adapting instructions written for a local AMD
 machine.
 
-| Area                   | SaladCloud-specific                                                                             | AMD/ROCm-specific                                                                                                          |
-| ---------------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| GPU selection          | You select GPU class IDs and priority in the Portal or through API.                             | The image and application must support the selected GPU's `gfx` architecture.                                              |
-| Host and device access | SaladCloud allocates the node and GPU. You do not configure the host from inside the container. | ROCm depends on an AMD host driver and compatible user-space libraries. Your image supplies the user-space stack.          |
-| Container image        | SaladCloud pulls and runs the image you configure.                                              | The image must contain ROCm-enabled frameworks, libraries, compiled extensions, and any diagnostic utilities you need.     |
-| Diagnostics            | Use the web terminal, Container Logs, and System Events to inspect a replica.                   | Tools such as `rocminfo` and `amd-smi` report AMD runtime and device information only when they are included in the image. |
-| Resilience             | Nodes are distributed and instances can be reallocated.                                         | Validate the exact software stack on every AMD class you select and repeat validation after reallocation.                  |
+| Area                   | SaladCloud-specific                                                                                                              | AMD/ROCm-specific                                                                                                        |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| GPU selection          | You select GPU class IDs and priority in the Portal or through API.                                                              | The image and application must support the selected GPU's `gfx` architecture.                                            |
+| Host and device access | SaladCloud manages the host stack, exposes `/dev/dxg`, and provides the runtime bridge libraries. You do not configure the host. | ROCm uses the WSL2 GPU bridge instead of native Linux device nodes and kernel modules.                                   |
+| Container image        | SaladCloud pulls the image and integrates it with the managed WSL2 GPU runtime.                                                  | The image supplies a compatible OS and glibc, framework, application libraries, compiled extensions, and utilities.      |
+| Diagnostics            | Use `/dev/dxg`, the web terminal, Container Logs, and System Events to inspect a replica.                                        | Use `rocminfo` and a real framework operation; AMD SMI cannot use a native `amdgpu` interface that WSL2 does not expose. |
+| Resilience             | Nodes are distributed and instances can be reallocated.                                                                          | Validate the exact software stack on every AMD class you select and repeat validation after reallocation.                |
 
 ## Recommended Deployment Path
 
@@ -83,8 +84,8 @@ passed on every selected class.
 
 ROCm compatibility is a chain:
 
-`Salad GPU class` → `host driver and device access` → `ROCm user space` → `framework and libraries` →
-`application kernels and features`
+`Salad GPU class` → `WSL2 /dev/dxg bridge and runtime libraries` → `container OS and glibc ABI` → `ROCm user space` →
+`framework and libraries` → `application kernels and features`
 
 A mismatch at any layer can allow the container to start while a framework import, kernel launch, or specific model
 feature still fails.
@@ -93,34 +94,40 @@ feature still fails.
 
 - Prefer a versioned, AMD-published framework image as a starting point when one fits the workload. AMD validation is
   useful upstream evidence, but it does not prove that the image and application have passed on a Salad GPU class.
+- Match the container distribution and ABI to the Salad WSL2 runtime libraries. Validate the framework import and a real
+  GPU operation before using the image in production.
 - Pin the tested image by digest where practical. Otherwise, use a version-specific tag and record the resolved digest.
 - Check AMD's current
   [ROCm compatibility matrix](https://rocm.docs.amd.com/en/latest/compatibility/compatibility-matrix.html) and the
   framework's compatibility documentation.
 - Confirm that the framework and every compiled extension contain code for the selected `gfx` target. If one image will
   serve multiple AMD classes, build and test every required target.
-- Include `rocminfo`, AMD SMI, and profiling tools in a diagnostic image or production image when you need them. GPU
-  selection does not add missing executables to the container.
-- Provide ROCm user-space libraries in the image. Do not attempt to install or replace the host kernel driver from the
-  container.
+- Include `rocminfo` in a diagnostic image when you need to identify the GPU and `gfx` target. GPU selection does not
+  add missing executables to the container.
+- Provide ROCm user-space libraries in the image. Do not attempt to install a Linux GPU kernel driver or replace the
+  SaladCloud WSL2 runtime libraries from the container.
 - Install application dependencies and compile extensions while building the image instead of at replica startup.
   Smaller, reproducible runtime images reduce download and initialization work on newly allocated nodes.
 - Test the real workload. Successful device enumeration or a framework import is only a smoke test.
 
-AMD publishes a separate
-[user-space and AMD GPU driver compatibility matrix](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/user-kernel-space-compat-matrix.html).
-Use it when diagnosing compatibility.
+For WSL2 concepts and supported upstream combinations, use AMD's
+[WSL compatibility matrix](https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/compatibility/compatibilityrad/wsl/wsl_compatibility.html)
+and
+[PyTorch on ROCm for WSL instructions](https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/install/installrad/wsl/legacywsl/install-pytorch.html).
 
-## Local Docker Instructions Versus SaladCloud
+## SaladCloud's WSL2 GPU Runtime
 
-AMD's local Docker documentation shows host options such as `--device /dev/kfd`, `--device /dev/dri`,
-`--group-add video`, and `--security-opt`. Those options configure a Docker host that you administer. They are not
-container-group settings to copy into SaladCloud.
+Salad Container Engine runs every container instance inside WSL2. AMD GPUs are exposed through the WSL2 GPU path, not
+the native Linux ROCm path. The relevant low-level device inside the container is `/dev/dxg`; do not use `/dev/kfd` or
+`/dev/dri` as SaladCloud health checks.
+
+AMD's local WSL2 Docker instructions include device and library-mount options for a host you administer. Do not copy
+those `docker run` options into a SaladCloud container group. They are host configuration, not container-group settings.
 
 On SaladCloud, select an AMD class in the container's
 [resource requirements](/container-engine/explanation/container-groups/container-groups#container-group-components).
-SaladCloud handles the host and GPU allocation. Configure only the container-level resources and settings exposed by the
-Portal or API.
+SaladCloud handles the WSL2 host integration, GPU allocation, device access, and runtime-library integration. Configure
+only the container-level resources and settings exposed by the Portal or API.
 
 ## Validate the Deployed Combination
 
@@ -128,8 +135,8 @@ Validate in layers so a failure identifies the boundary that needs attention:
 
 1. **Allocation:** Confirm that the replica reaches `Running` on the intended AMD class. Review
    [System Events](/container-engine/explanation/container-groups/system-events) if it repeatedly exits or reallocates.
-2. **Device discovery:** If the image includes them, use the read-only `rocminfo` and `amd-smi list` diagnostics to
-   confirm that the expected AMD device is visible.
+2. **Device discovery:** Confirm that `/dev/dxg` is present, then use `rocminfo` when the image includes it. Do not use
+   AMD SMI as a required check because SaladCloud's WSL2 environment does not expose the native Linux `amdgpu` module.
 3. **Framework backend:** Confirm that the installed framework is a ROCm build and reports a usable GPU.
 4. **GPU execution:** Run a real tensor or kernel operation and synchronize it so asynchronous errors surface.
 5. **Application path:** Exercise the actual model, precision, quantization, attention backend, custom operators, and
@@ -184,16 +191,18 @@ out-of-memory behavior and sustained throughput as application-level acceptance 
 
 ### Profile Before Tuning
 
-Establish a latency, throughput, and memory baseline before changing ROCm or framework settings. Use application-level
-profiling or AMD tools such as `rocprofv3` when they are included in the image, then re-profile to confirm that a change
-actually improves the workload.
+Establish a latency, throughput, and memory baseline before changing ROCm or framework settings. Start with
+application-level timing and confirm that the chosen profiler works in the exact image and workload. Measure again after
+every change to confirm that it improves the real workload.
 
-### Use Read-Only Telemetry
+### Validate Telemetry on WSL2
 
-Use `amd-smi` for interactive, read-only inspection when it is available in the image. For a production telemetry
-integration, prefer the AMD SMI Python or C++ library over parsing CLI output, and record the AMD SMI version used by
-the collector. Do not design a Salad workload around host-management operations such as GPU reset, clock, or power
-changes.
+Do not use AMD SMI success as a readiness requirement on SaladCloud. It relies on the native Linux `amdgpu` interface,
+which is not exposed by SaladCloud's WSL2 runtime. Use `/dev/dxg`, `rocminfo` when available, and a real framework
+operation to verify GPU access.
+
+Use application- or framework-level measurements for initial validation. Before adopting any GPU telemetry collector,
+validate it on the exact Salad class, image, and WSL2 runtime.
 
 ### Roll Out Changes as New Compatibility Sets
 
@@ -215,10 +224,17 @@ for the ROCm artifact and only NVIDIA classes for the CUDA artifact.
 
 ### No AMD Device Is Visible
 
-Confirm that the replica received the intended AMD class. Also inspect `ROCR_VISIBLE_DEVICES`, `HIP_VISIBLE_DEVICES`,
-and `CUDA_VISIBLE_DEVICES`; each can restrict which AMD devices a HIP application sees. If the device is still
-unavailable, collect the class ID/name, image digest, diagnostic output, Container Logs, and System Events for Salad
-support.
+Confirm that the replica received the intended AMD class and that `/dev/dxg` is present. Also inspect
+`ROCR_VISIBLE_DEVICES`, `HIP_VISIBLE_DEVICES`, and `CUDA_VISIBLE_DEVICES`; each can restrict which AMD devices a HIP
+application sees. If the device is still unavailable, collect the class ID/name, image digest, diagnostic output,
+Container Logs, and System Events for Salad support. Do not try to create or mount GPU devices from inside the
+container.
+
+### AMD SMI Reports That `amdgpu` Is Not Loaded
+
+SaladCloud's WSL2 environment does not expose the native Linux `amdgpu` kernel module. Do not run the suggested
+`sudo modprobe amdgpu` command inside a Salad container: the native Linux kernel module is not the device path used by
+SaladCloud. Use `rocminfo` and a real framework operation as the acceptance tests.
 
 ### `torch.cuda.is_available()` Is `False`
 
@@ -260,12 +276,10 @@ AMD GPUs.
 
 ## Related AMD and Framework Documentation
 
-- [AMD: Run ROCm Docker containers](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/docker.html)
 - [AMD: ROCm compatibility matrix](https://rocm.docs.amd.com/en/latest/compatibility/compatibility-matrix.html)
-- [AMD: User-space and AMD GPU driver compatibility](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/user-kernel-space-compat-matrix.html)
-- [AMD: PyTorch on ROCm installation](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/pytorch-install.html)
+- [AMD: WSL compatibility matrix](https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/compatibility/compatibilityrad/wsl/wsl_compatibility.html)
+- [AMD: PyTorch on ROCm for WSL](https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/install/installrad/wsl/legacywsl/install-pytorch.html)
 - [AMD: PyTorch compatibility](https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/pytorch-compatibility.html)
-- [AMD: AMD SMI CLI](https://rocm.docs.amd.com/projects/amdsmi/en/latest/how-to/amdsmi-cli-tool.html)
 - [AMD: HIP environment variables](https://rocm.docs.amd.com/projects/HIP/en/latest/reference/env_variables.html)
 - [AMD: HIP performance guidelines](https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/performance_guidelines.html)
 - [PyTorch: HIP semantics](https://docs.pytorch.org/docs/stable/notes/hip.html)

--- a/container-engine/reference/recipes/kokoro-tts-api.mdx
+++ b/container-engine/reference/recipes/kokoro-tts-api.mdx
@@ -1,0 +1,143 @@
+---
+title: Kokoro TTS API
+sidebarTitle: Kokoro TTS API
+description:
+  Deploy hexgrad/Kokoro-82M as an OpenAI-compatible text-to-speech API for narration, voice agents, accessibility, and
+  audio generation.
+---
+
+_Last Updated: July 13, 2026_
+
+<Tip>Deploy from the [SaladCloud Portal](https://portal.salad.com).</Tip>
+
+## Overview
+
+This recipe runs [`hexgrad/Kokoro-82M`](https://huggingface.co/hexgrad/Kokoro-82M) behind an OpenAI-compatible
+text-to-speech API. Send text to the deployment and receive generated audio in formats including MP3, WAV, FLAC, Opus,
+AAC, and PCM.
+
+Kokoro is an 82 million parameter open-weight TTS model. Its small size makes it useful for cost-conscious speech
+generation such as product narration, voice agents, accessibility features, audio previews, and batch audio workflows.
+The server supports more than 50 Kokoro voices and produces 24 kHz audio.
+
+## Quick Start
+
+1. Open the [SaladCloud Portal](https://portal.salad.com).
+2. Deploy the **Kokoro TTS API** recipe.
+3. Enter a **Container Group Name**.
+4. Decide whether to enable **Require Container Gateway Authentication**:
+   - Enabled: requests must include your SaladCloud API key.
+   - Disabled: anyone with the URL can call the TTS service.
+5. Deploy and wait until the replica is ready.
+
+<Callout variation="note">
+  Startup downloads and initializes the model. It can take several minutes before the health check passes.
+</Callout>
+
+## Defaults
+
+The recipe comes preconfigured with these defaults:
+
+- Model ID: `hexgrad/Kokoro-82M`
+- Container image: `hwdsl2/kokoro-server:latest`
+- Command equivalent: `python3 -m uvicorn api_server:app --host :: --port 8880`
+- Container port: `8880`
+- Default voice: `af_heart`
+- Default speed: `1.0`
+- Default sample rate: 24 kHz
+- Model cache: `/var/lib/kokoro`
+- Readiness and liveness probe: `GET /health`
+- Authentication: enabled by default through the Salad Container Gateway
+
+The recipe overrides the image's startup command so Uvicorn binds to IPv6 host `::`, which allows Salad ingress to reach
+the API. The container's own bearer-token authentication is disabled with an empty `KOKORO_API_KEY`; use the Salad
+Container Gateway authentication setting to control public access.
+
+## API Endpoints
+
+Useful endpoints include:
+
+- `GET /health` - readiness probe and health check
+- `GET /v1/models` - model information
+- `GET /v1/voices` - available voices
+- `GET /docs` - Swagger documentation
+- `POST /v1/audio/speech` - generate speech audio from text
+
+## Authentication
+
+**Require Container Gateway Authentication** is available in the deployment form and is enabled by default.
+
+- Enabled: every request must include the `Salad-Api-Key` header.
+- Disabled: anyone with the deployment URL can call the API.
+
+If you enable authentication, see [Sending Requests](/container-engine/how-to-guides/gateway/sending-requests) for the
+header format.
+
+## Example Request
+
+This request generates a WAV file named `kokoro.wav`:
+
+```bash
+curl https://<your-dns>.salad.cloud/v1/audio/speech \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'Salad-Api-Key: <api-key>' \
+  -d '{
+    "model": "kokoro",
+    "input": "Kokoro is now running on SaladCloud.",
+    "voice": "af_heart",
+    "response_format": "wav",
+    "speed": 1.0
+  }' \
+  --output kokoro.wav
+```
+
+If you disabled authentication during deployment, omit the `Salad-Api-Key` header.
+
+The endpoint returns binary audio rather than JSON. For this request, the response has `Content-Type: audio/wav`. If you
+omit `response_format`, the server returns MP3 audio by default.
+
+The API accepts `kokoro`, `tts-1`, or `tts-1-hd` in the `model` field. All three values use `hexgrad/Kokoro-82M` on this
+server.
+
+## Test A Deployment
+
+Check health:
+
+```bash
+curl https://<your-dns>.salad.cloud/health
+```
+
+List available voices:
+
+```bash
+curl https://<your-dns>.salad.cloud/v1/voices
+```
+
+Generate a short WAV file, then inspect its format:
+
+```bash
+curl -sS https://<your-dns>.salad.cloud/v1/audio/speech \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"kokoro","input":"SaladCloud text to speech test.","voice":"af_heart","response_format":"wav"}' \
+  --output kokoro-test.wav
+
+file kokoro-test.wav
+```
+
+The `file` command should identify `kokoro-test.wav` as WAV audio. Add the `Salad-Api-Key` header to each request if
+gateway authentication is enabled.
+
+## Configuration Notes
+
+- Supported response formats are `mp3`, `wav`, `flac`, `opus`, `aac`, and `pcm`.
+- Language codes include `a` for American English, `b` for British English, `e` for Spanish, `f` for French, `h` for
+  Hindi, `i` for Italian, `j` for Japanese, `p` for Brazilian Portuguese, and `z` for Mandarin Chinese. Leave the
+  language code blank to infer the pipeline from the selected voice.
+
+## Source Code
+
+- [<Icon icon="github" size="24" /> Recipe Source](https://github.com/SaladTechnologies/salad-recipes/tree/master/recipes/kokoro-tts-api)
+- [Kokoro GitHub repository](https://github.com/hexgrad/kokoro)
+- [hexgrad/Kokoro-82M model card](https://huggingface.co/hexgrad/Kokoro-82M)
+- [Kokoro Docker server](https://github.com/hwdsl2/docker-kokoro)

--- a/container-engine/reference/recipes/tei-bge-reranker-v2-m3.mdx
+++ b/container-engine/reference/recipes/tei-bge-reranker-v2-m3.mdx
@@ -1,0 +1,170 @@
+---
+title: BGE Reranker with Text Embeddings Inference
+sidebarTitle: BGE Reranker
+description:
+  Serve BAAI/bge-reranker-v2-m3 with Hugging Face Text Embeddings Inference to score and rerank candidate documents for
+  search and RAG.
+---
+
+_Last Updated: July 13, 2026_
+
+<Tip>Deploy from the [SaladCloud Portal](https://portal.salad.com).</Tip>
+
+## Overview
+
+This recipe runs [`BAAI/bge-reranker-v2-m3`](https://huggingface.co/BAAI/bge-reranker-v2-m3) with
+[Hugging Face Text Embeddings Inference](https://github.com/huggingface/text-embeddings-inference) on a Salad GPU. It
+accepts a query and candidate passages, scores each query-passage pair, and returns the candidates in descending order
+of relevance.
+
+A reranker complements embedding and vector search. Vector search efficiently retrieves a broad candidate set, while a
+reranker evaluates each candidate together with the original query to improve the final ordering. In a RAG pipeline,
+this helps select the most relevant passages before sending context to an LLM.
+
+`BAAI/bge-reranker-v2-m3` is a multilingual reranker based on XLM-RoBERTa. It supports inputs up to 8192 tokens and is a
+good fit for multilingual search, document retrieval, and RAG result refinement.
+
+## Quick Start
+
+1. Open the [SaladCloud Portal](https://portal.salad.com).
+2. Deploy the **BGE Reranker API** recipe.
+3. Enter a **Container Group Name**.
+4. Decide whether to enable **Require Container Gateway Authentication**:
+   - Enabled: requests must include your SaladCloud API key.
+   - Disabled: anyone with the URL can call the reranking service.
+5. Deploy and wait for the model to download and the replica to become ready.
+
+<Callout variation="note">
+  The model is downloaded from Hugging Face at startup, so it can take several minutes before the deployment becomes
+  ready.
+</Callout>
+
+## Defaults
+
+The recipe comes preconfigured with these defaults:
+
+- Server: Hugging Face Text Embeddings Inference
+- Model ID: `BAAI/bge-reranker-v2-m3`
+- Container image: `ghcr.io/huggingface/text-embeddings-inference:89-1.9`
+- Command equivalent: `text-embeddings-router --model-id BAAI/bge-reranker-v2-m3 --port 3000`
+- Container port: `3000`
+- Host bind: `::`
+- Data type: `float16`
+- Max batch tokens: `16384`
+- Max client batch size: `32`
+- Readiness probe: `GET /health`
+- Authentication: enabled by default
+
+## API Endpoints
+
+Useful TEI endpoints include:
+
+- `GET /health` - readiness probe and health check
+- `GET /info` - model and server metadata
+- `GET /docs` - Swagger documentation
+- `POST /rerank` - score and rank one query against candidate texts
+- `POST /predict` - score query-text pairs using TEI's prediction interface
+
+## Authentication
+
+**Require Container Gateway Authentication** is available in the deployment form and is enabled by default.
+
+- Enabled: every request must include the `Salad-Api-Key` header.
+- Disabled: anyone with the deployment URL can call the API.
+
+If you enable authentication, see [Sending Requests](/container-engine/how-to-guides/gateway/sending-requests) for the
+header format.
+
+## Example Request
+
+Send one query and multiple candidate passages to `/rerank`:
+
+```bash
+curl https://<your-dns>.salad.cloud/rerank \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'Salad-Api-Key: <api-key>' \
+  -d '{
+    "query": "What is a reranker used for in RAG?",
+    "texts": [
+      "A reranker scores retrieved passages against the query and improves the final ordering before generation.",
+      "Embeddings convert text into vectors for approximate nearest neighbor search.",
+      "Container images package an application and its runtime dependencies."
+    ],
+    "raw_scores": false,
+    "return_text": true
+  }'
+```
+
+If you disabled authentication during deployment, omit the `Salad-Api-Key` header.
+
+The response is sorted by descending relevance. Scores depend on the input and model version, but the response shape is:
+
+```json
+[
+  {
+    "index": 0,
+    "text": "A reranker scores retrieved passages against the query and improves the final ordering before generation.",
+    "score": 0.9971
+  },
+  {
+    "index": 1,
+    "text": "Embeddings convert text into vectors for approximate nearest neighbor search.",
+    "score": 0.2164
+  },
+  {
+    "index": 2,
+    "text": "Container images package an application and its runtime dependencies.",
+    "score": 0.0048
+  }
+]
+```
+
+Each `index` refers to the candidate's position in the original `texts` array. Set `return_text` to `false` if your
+application already tracks documents by index and does not need passage text repeated in the response. Set `raw_scores`
+to `true` only if you need raw model logits instead of normalized relevance scores.
+
+## Test A Deployment
+
+Check health:
+
+```bash
+curl https://<your-dns>.salad.cloud/health
+```
+
+Check model metadata:
+
+```bash
+curl https://<your-dns>.salad.cloud/info
+```
+
+Confirm that the endpoint ranks the relevant passage first:
+
+```bash
+curl -s https://<your-dns>.salad.cloud/rerank \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "query":"Where is the Eiffel Tower?",
+    "texts":["The Eiffel Tower is in Paris.","Whales are marine mammals."],
+    "return_text":true
+  }' \
+  | jq '.[0]'
+```
+
+The first result should have `index` equal to `0`. Add the `Salad-Api-Key` header if gateway authentication is enabled.
+
+## Tuning Notes
+
+- Keep `MODEL_ID` set to `BAAI/bge-reranker-v2-m3` unless you intentionally want to repurpose the recipe.
+- The default `MAX_CLIENT_BATCH_SIZE` allows up to 32 candidate texts in one `/rerank` request. Increase it only after
+  testing memory usage and latency with your expected passage lengths.
+- Long passages and large candidate lists consume more VRAM. Lower `MAX_BATCH_TOKENS` if replicas run out of memory.
+- For larger retrieval sets, retrieve broadly with vector search and rerank a smaller top-k candidate set rather than
+  sending the full corpus to the reranker.
+
+## Source Code
+
+- [<Icon icon="github" size="24" /> Recipe Source](https://github.com/SaladTechnologies/salad-recipes/tree/master/recipes/tei-bge-reranker-v2-m3)
+- [BAAI/bge-reranker-v2-m3 model card](https://huggingface.co/BAAI/bge-reranker-v2-m3)
+- [Hugging Face Text Embeddings Inference](https://huggingface.co/docs/text-embeddings-inference)
+- [FlagEmbedding](https://github.com/FlagOpen/FlagEmbedding)

--- a/container-engine/tutorials/machine-learning/pytorch-amd-rocm.mdx
+++ b/container-engine/tutorials/machine-learning/pytorch-amd-rocm.mdx
@@ -1,0 +1,359 @@
+---
+title: Run PyTorch on AMD GPUs with ROCm
+sidebarTitle: PyTorch on AMD GPUs
+description: Select, deploy, and validate a ROCm-enabled PyTorch container on an AMD GPU in SaladCloud.
+---
+
+_Last Updated: July 13, 2026_
+
+Use this tutorial to qualify a ROCm-enabled PyTorch image on an AMD GPU class that is currently available to your
+SaladCloud organization. The workflow deliberately discovers the GPU class at deployment time instead of publishing a
+potentially stale class ID.
+
+<Warning>
+  A passing smoke test validates only the exact Salad GPU class, image, and operation that you tested. It does not
+  establish that every `rocm/pytorch` image, PyTorch feature, model, precision, or quantization works on that class.
+</Warning>
+
+## What You Will Do
+
+You will:
+
+1. Select one AMD GPU class and a versioned ROCm-enabled PyTorch image.
+2. Deploy one SaladCloud replica for an initial diagnostic test.
+3. Confirm that PyTorch is using ROCm and complete a deterministic matrix multiplication on the GPU.
+4. Record the tested combination, then repeat the real workload across multiple allocations.
+
+## Prerequisites
+
+- A SaladCloud organization and project.
+- Portal access, or a SaladCloud API key for the optional API workflow.
+- Access to an AMD GPU class in that organization. Current inventory and capacity can vary.
+- A versioned `rocm/pytorch` image selected for the AMD GPU architecture you intend to use.
+- Enough credits to run the validation and any multi-replica follow-up.
+- For the API workflow, `curl` and `jq` on your local machine.
+
+Read [AMD GPUs and ROCm](/container-engine/reference/amd-gpus) before adapting a CUDA application or selecting more than
+one AMD class.
+
+## 1. Select a GPU and Image
+
+In the SaladCloud Portal, note the AMD GPU class currently offered to your organization. You can also retrieve current
+class names and IDs with the [List GPU Classes API](/reference/saladcloud-api/organizations/list-gpu-classes). Do not
+reuse a class UUID from an unrelated example.
+
+After choosing the class and container resources, use the
+[GPU Availability API](/reference/saladcloud-api/organizations/get-gpu-availability) before a multi-replica test. The
+result is an estimate, so plan for capacity to change as nodes enter and leave the network.
+
+Use the class's GPU model to review AMD's current
+[PyTorch compatibility documentation](https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/pytorch-compatibility.html)
+and
+[PyTorch on ROCm installation guide](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/pytorch-install.html).
+Choose a versioned `rocm/pytorch` tag whose ROCm, PyTorch, Python, and operating-system combination fits your
+application. If you cannot match the Salad class to AMD's compatibility information, confirm the combination with Salad
+support rather than assuming compatibility.
+
+Do not use the mutable `latest` tag as a production pin. Preserve the exact versioned tag and, when your image workflow
+exposes it, the resolved image digest.
+
+Treat these values as one compatibility set:
+
+| Component           | Value to preserve                                                         |
+| ------------------- | ------------------------------------------------------------------------- |
+| Salad GPU selection | Class name and ID returned for your organization                          |
+| Container image     | Full versioned tag and resolved digest, when available                    |
+| Framework stack     | ROCm/HIP, PyTorch, Python, and application versions                       |
+| Application path    | Model, precision, quantization, custom operators, and relevant parameters |
+| Container resources | CPU, RAM, storage, command, environment variables, and replica settings   |
+
+Changing one of these values creates a new combination that needs to be validated again.
+
+## 2. Deploy Through the Portal
+
+1. Open the [SaladCloud Portal](https://portal.salad.com) and select your organization and project.
+2. Click **Deploy a Container Group**, then choose **Custom**.
+3. Enter a name for the validation group and set **Image Source** to the versioned `rocm/pytorch` image you selected.
+4. Set **Replicas** to `1` for the initial diagnostic test.
+5. Under **Hardware**, select only the AMD GPU class you are validating.
+6. Select CPU, RAM, and storage for the image and workload you intend to test. A small matrix test does not establish
+   production resource requirements.
+7. If the image's default process exits, add a long-running command such as `sleep infinity` only after confirming that
+   the command exists in the exact image. A command override replaces the image's configured entrypoint and command.
+8. No Container Gateway is required for this terminal-based test.
+9. Deploy the group and wait for its instance to reach **Running**. If it repeatedly exits or reallocates, inspect
+   [System Events](/container-engine/explanation/container-groups/system-events) before changing the ROCm stack.
+10. Open the running instance and select the **Terminal** tab. See
+    [SSH and terminal access](/container-engine/explanation/container-groups/ssh-and-terminal).
+
+Do not copy local Docker host options such as `--device /dev/kfd` or `--device /dev/dri` into the container group.
+SaladCloud handles GPU allocation after you select the GPU class. The distinction is explained in
+[Local Docker Instructions Versus SaladCloud](/container-engine/reference/amd-gpus#local-docker-instructions-versus-saladcloud).
+
+## 3. Verify PyTorch ROCm
+
+First, show whether the container configuration explicitly restricts GPU visibility:
+
+```bash
+env | grep -E '^(ROCR_VISIBLE_DEVICES|HIP_VISIBLE_DEVICES|CUDA_VISIBLE_DEVICES)=' || true
+```
+
+An empty result means that none of these variables is explicitly set. Unexpected values can hide devices from the
+application; compare them with the container group configuration before changing them.
+
+Then run a deterministic operation in the Salad terminal:
+
+```bash
+python3 - <<'PY'
+import torch
+
+print("PyTorch:", torch.__version__)
+print("ROCm/HIP:", torch.version.hip)
+print("CUDA build:", torch.version.cuda)
+print("GPU available:", torch.cuda.is_available())
+print("GPU count:", torch.cuda.device_count())
+
+if not torch.version.hip:
+    raise SystemExit("This is not a ROCm-enabled PyTorch build")
+
+if not torch.cuda.is_available() or torch.cuda.device_count() < 1:
+    raise SystemExit("PyTorch cannot access an AMD GPU")
+
+device = torch.device("cuda:0")
+print("GPU:", torch.cuda.get_device_name(0))
+
+a = torch.ones((1024, 1024), device=device)
+b = torch.ones((1024, 1024), device=device)
+c = a @ b
+torch.cuda.synchronize(device)
+
+if c.device != device:
+    raise SystemExit(f"Result ran on unexpected device: {c.device}")
+
+actual = c[0, 0].item()
+if actual != 1024.0:
+    raise SystemExit(f"Unexpected result: {actual}")
+
+print("Result device:", c.device)
+print("Result shape:", tuple(c.shape))
+print("Result check:", actual)
+PY
+```
+
+PyTorch on ROCm deliberately uses the `torch.cuda` namespace and `cuda` device strings. The separate `torch.version.hip`
+check prevents a CUDA build on an NVIDIA GPU from passing this ROCm test. See
+[PyTorch HIP semantics](https://docs.pytorch.org/docs/stable/notes/hip.html).
+
+## Interpret the Result
+
+The test passes when:
+
+- `ROCm/HIP` contains a version and `CUDA build` is normally `None`.
+- `GPU available` is `True`.
+- `GPU count` is at least `1`. Under the current Container Engine model, each container instance has one attached GPU,
+  so the expected count is `1`.
+- The reported GPU corresponds to the AMD class selected for the container group.
+- The result device is `cuda:0`, the shape is `(1024, 1024)`, and the result check is `1024.0`.
+
+This test allocates its inputs on the GPU, waits for asynchronous GPU work to finish, verifies the output device, and
+checks a known result. It is stronger than device enumeration, but it is not a substitute for running the real
+application.
+
+## Optional ROCm Diagnostics
+
+The selected image might include `rocminfo` or AMD SMI. Use these read-only commands to record the detected architecture
+and device when they are available:
+
+```bash
+if command -v rocminfo >/dev/null 2>&1; then
+  rocminfo | grep -m 1 -E 'Name:[[:space:]]+gfx'
+else
+  echo "rocminfo is not installed in this image"
+fi
+
+if command -v amd-smi >/dev/null 2>&1; then
+  amd-smi version
+  amd-smi list
+else
+  echo "amd-smi is not installed in this image"
+fi
+```
+
+These tools are supplied by the container image, not added automatically by GPU selection. A missing utility identifies
+an image-inventory issue; it does not by itself override a passing PyTorch GPU test. Add the tool to a diagnostic image
+when you need its output.
+
+## 4. Validate the Real Workload
+
+After the smoke test passes, run the exact production path. Include:
+
+- The real model and representative input sizes.
+- Every precision, quantization format, attention backend, and custom operator you will enable.
+- Model loading, warm-up, and peak GPU and system-memory use.
+- Any compiled PyTorch extension, checked for the detected `gfx` target.
+- Application startup and readiness behavior after a fresh allocation.
+- Sustained latency and throughput under the expected concurrency.
+
+For production qualification, repeat the checks on at least three separately allocated replicas when capacity permits,
+then repeat them after a reallocation. If you add another AMD class, validate the same image and workload independently
+on that class.
+
+## Record the Result and Clean Up
+
+Save enough information to reproduce the result:
+
+| Field                     | What to record                                                   |
+| ------------------------- | ---------------------------------------------------------------- |
+| Test identity             | Date, operator, organization, project, and container group       |
+| Salad hardware            | GPU class name and ID                                            |
+| Immutable image identity  | Versioned image tag and resolved digest, when available          |
+| Reported stack            | ROCm/HIP, PyTorch, Python, application, and AMD SMI versions     |
+| Detected device           | PyTorch device name and `gfx` target, when `rocminfo` is present |
+| Container configuration   | CPU, RAM, storage, command, environment variables, and replicas  |
+| Application configuration | Model, precision, quantization, custom operators, and input size |
+| Evidence                  | PyTorch output, application output, logs, and System Events      |
+| Allocation coverage       | Replica IDs, reallocation result, and pass or fail               |
+
+When validation is complete, stop or delete the test container group in the Portal so it does not continue consuming
+credits.
+
+## Optional API Deployment
+
+The Portal's **Copy Configuration** action is the simplest way to obtain an API payload that matches a configuration you
+have already reviewed. The following path performs class discovery and creates the same one-replica validation group
+without embedding a sample GPU UUID.
+
+Set the SaladCloud identifiers first:
+
+```bash
+export SALAD_ORGANIZATION='<organization-name>'
+export SALAD_PROJECT='<project-name>'
+export SALAD_API_KEY='<api-key>'
+```
+
+Retrieve the current classes and their resource limits:
+
+```bash
+curl --fail-with-body --silent --show-error \
+  --request GET \
+  --url "https://api.salad.com/api/public/organizations/${SALAD_ORGANIZATION}/gpu-classes" \
+  --header "Salad-Api-Key: ${SALAD_API_KEY}" \
+  --header 'accept: application/json' \
+  | jq '.items[] | {name, id, min_vcpu, max_vcpu, min_ram, max_ram, min_storage, max_storage}'
+```
+
+The response does not include a separate vendor field. Match the AMD class name with the class shown in the Portal, then
+copy its returned ID. Set the remaining values from the versioned image and resource configuration you intend to
+validate:
+
+```bash
+export CONTAINER_GROUP_NAME='pytorch-amd-rocm-check'
+export AMD_GPU_CLASS_ID='<id-returned-by-list-gpu-classes>'
+export ROCM_PYTORCH_IMAGE='rocm/pytorch:<versioned-tag>'
+export CONTAINER_CPU='<cpu-count>'
+export CONTAINER_MEMORY_MB='<memory-in-mb>'
+export CONTAINER_STORAGE_BYTES='<storage-in-bytes>'
+```
+
+The payload below uses `sleep infinity` to keep the diagnostic container available for terminal access. Confirm that
+`sleep` accepts `infinity` in the exact image, or replace the `command` array with a long-running command that you have
+tested in that image.
+
+```bash
+jq -n \
+  --arg name "$CONTAINER_GROUP_NAME" \
+  --arg image "$ROCM_PYTORCH_IMAGE" \
+  --arg gpu_class "$AMD_GPU_CLASS_ID" \
+  --argjson cpu "$CONTAINER_CPU" \
+  --argjson memory "$CONTAINER_MEMORY_MB" \
+  --argjson storage "$CONTAINER_STORAGE_BYTES" \
+  '{
+    name: $name,
+    display_name: "PyTorch AMD ROCm Check",
+    container: {
+      image: $image,
+      resources: {
+        cpu: $cpu,
+        memory: $memory,
+        storage_amount: $storage,
+        gpu_classes: [$gpu_class]
+      },
+      command: ["sleep", "infinity"]
+    },
+    autostart_policy: false,
+    restart_policy: "always",
+    replicas: 1
+  }' \
+  | curl --fail-with-body --silent --show-error \
+      --request POST \
+      --url "https://api.salad.com/api/public/organizations/${SALAD_ORGANIZATION}/projects/${SALAD_PROJECT}/containers" \
+      --header "Salad-Api-Key: ${SALAD_API_KEY}" \
+      --header 'accept: application/json' \
+      --header 'content-type: application/json' \
+      --data @- \
+  | jq
+```
+
+The group is created in a stopped state so you can review it. Start it with:
+
+```bash
+curl --fail-with-body --silent --show-error \
+  --request POST \
+  --url "https://api.salad.com/api/public/organizations/${SALAD_ORGANIZATION}/projects/${SALAD_PROJECT}/containers/${CONTAINER_GROUP_NAME}/start" \
+  --header "Salad-Api-Key: ${SALAD_API_KEY}" \
+  --header 'accept: application/json' \
+  | jq
+```
+
+Use the Portal to watch the instance and open its terminal, or use the
+[Get Container Group API](/reference/saladcloud-api/container-groups/get-container-group) to inspect status. After the
+test, delete the group through the Portal or the
+[Delete Container Group API](/reference/saladcloud-api/container-groups/delete-container-group).
+
+## Troubleshooting
+
+### The Instance Does Not Stay Running
+
+Review Container Logs and System Events. Check the selected GPU vendor, the image's default process or command override,
+and the configured CPU, RAM, and storage before changing ROCm or PyTorch versions.
+
+### `ROCm/HIP` Is Empty
+
+The installed PyTorch build is not ROCm-enabled. Confirm the image reference and inspect any dependency-install step
+that might have replaced the image's ROCm build of PyTorch. Rebuild from a PyTorch version listed for the selected ROCm
+release in AMD's compatibility documentation.
+
+### PyTorch Cannot Access an AMD GPU
+
+Confirm that the instance received the intended AMD class. Inspect `ROCR_VISIBLE_DEVICES`, `HIP_VISIBLE_DEVICES`, and
+`CUDA_VISIBLE_DEVICES` for unexpected restrictions. If `torch.version.hip` is populated but no device is available,
+collect the class name and ID, image tag and digest, PyTorch output, Container Logs, and System Events for Salad
+support.
+
+### `rocminfo` or `amd-smi` Is Missing
+
+The utility is not included in the image or is not on `PATH`. Add the required user-space package while building a
+diagnostic image. Do not try to install or replace the host GPU driver from the container.
+
+### `hipErrorNoBinaryForGPU`
+
+A PyTorch dependency or custom extension lacks compatible code for the current GPU. Identify the `gfx` target with
+`rocminfo` when it is available, check the compiled targets as described in AMD's PyTorch installation guide, rebuild
+the affected code, and retest. Do not use an architecture override as a generic workaround.
+
+### The Smoke Test Passes but the Application Fails
+
+Isolate the failing model feature, precision, quantization format, or compiled extension. Confirm upstream ROCm support
+for that exact feature, then validate it on the same Salad class and image. A generic PyTorch operation cannot establish
+application compatibility.
+
+For additional diagnosis, see [AMD GPU troubleshooting](/container-engine/reference/amd-gpus#troubleshooting) and
+[Salad Container Engine troubleshooting](/container-engine/how-to-guides/troubleshooting).
+
+## Next Steps
+
+- Build a custom image from the versioned ROCm base and install dependencies at image-build time.
+- Add application readiness checks that load the model and complete a representative GPU operation.
+- Preserve the validation record with the image source and deployment configuration.
+- Review the [AMD GPU production best practices](/container-engine/reference/amd-gpus#production-best-practices) before
+  increasing replicas or adding another AMD class.

--- a/container-engine/tutorials/machine-learning/pytorch-amd-rocm.mdx
+++ b/container-engine/tutorials/machine-learning/pytorch-amd-rocm.mdx
@@ -4,32 +4,34 @@ sidebarTitle: PyTorch on AMD GPUs
 description: Select, deploy, and validate a ROCm-enabled PyTorch container on an AMD GPU in SaladCloud.
 ---
 
-_Last Updated: July 13, 2026_
+_Last Updated: July 14, 2026_
 
-Use this tutorial to qualify a ROCm-enabled PyTorch image on an AMD GPU class that is currently available to your
-SaladCloud organization. The workflow deliberately discovers the GPU class at deployment time instead of publishing a
-potentially stale class ID.
+Use this tutorial to deploy and verify a ROCm-enabled PyTorch image on an AMD GPU class available to your SaladCloud
+organization.
+
+Salad Container Engine runs container instances inside WSL2. The image selection, device checks, and troubleshooting in
+this tutorial therefore focus only on the ROCm-on-WSL2 path used by SaladCloud.
 
 <Warning>
-  A passing smoke test validates only the exact Salad GPU class, image, and operation that you tested. It does not
-  establish that every `rocm/pytorch` image, PyTorch feature, model, precision, or quantization works on that class.
+  A passing PyTorch check validates basic ROCm access for the selected GPU class and image. It does not establish
+  support for a particular model, compiled extension, precision mode, quantization format, or production workload.
 </Warning>
 
 ## What You Will Do
 
 You will:
 
-1. Select one AMD GPU class and a versioned ROCm-enabled PyTorch image.
+1. Select an AMD GPU class and a compatible, versioned ROCm-enabled PyTorch image.
 2. Deploy one SaladCloud replica for an initial diagnostic test.
-3. Confirm that PyTorch is using ROCm and complete a deterministic matrix multiplication on the GPU.
-4. Record the tested combination, then repeat the real workload across multiple allocations.
+3. Confirm the GPU device and PyTorch ROCm backend, then complete a deterministic matrix multiplication on the GPU.
+4. Record the combination and test the real workload across multiple allocations.
 
 ## Prerequisites
 
 - A SaladCloud organization and project.
 - Portal access, or a SaladCloud API key for the optional API workflow.
 - Access to an AMD GPU class in that organization. Current inventory and capacity can vary.
-- A versioned `rocm/pytorch` image selected for the AMD GPU architecture you intend to use.
+- A versioned `rocm/pytorch` image compatible with the AMD architecture you intend to use.
 - Enough credits to run the validation and any multi-replica follow-up.
 - For the API workflow, `curl` and `jq` on your local machine.
 
@@ -38,9 +40,9 @@ one AMD class.
 
 ## 1. Select a GPU and Image
 
-In the SaladCloud Portal, note the AMD GPU class currently offered to your organization. You can also retrieve current
-class names and IDs with the [List GPU Classes API](/reference/saladcloud-api/organizations/list-gpu-classes). Do not
-reuse a class UUID from an unrelated example.
+Use the Portal or [List GPU Classes API](/reference/saladcloud-api/organizations/list-gpu-classes) to find the AMD
+classes available to your organization and retrieve the current class ID. Do not reuse a class UUID from an unrelated
+example.
 
 After choosing the class and container resources, use the
 [GPU Availability API](/reference/saladcloud-api/organizations/get-gpu-availability) before a multi-replica test. The
@@ -49,10 +51,14 @@ result is an estimate, so plan for capacity to change as nodes enter and leave t
 Use the class's GPU model to review AMD's current
 [PyTorch compatibility documentation](https://rocm.docs.amd.com/en/latest/compatibility/ml-compatibility/pytorch-compatibility.html)
 and
-[PyTorch on ROCm installation guide](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/pytorch-install.html).
-Choose a versioned `rocm/pytorch` tag whose ROCm, PyTorch, Python, and operating-system combination fits your
+[PyTorch on ROCm for WSL instructions](https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/install/installrad/wsl/legacywsl/install-pytorch.html).
+Choose a versioned `rocm/pytorch` tag whose ROCm, PyTorch, Python, operating system, and compiled architectures fit your
 application. If you cannot match the Salad class to AMD's compatibility information, confirm the combination with Salad
 support rather than assuming compatibility.
+
+[WSL compatibility matrix](https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/compatibility/compatibilityrad/wsl/wsl_compatibility.html)
+describes AMD's upstream WSL support. Treat upstream compatibility as a starting point and validate the selected image
+and workload on SaladCloud before deploying it to production.
 
 Do not use the mutable `latest` tag as a production pin. Preserve the exact versioned tag and, when your image workflow
 exposes it, the resolved image digest.
@@ -78,21 +84,32 @@ Changing one of these values creates a new combination that needs to be validate
 5. Under **Hardware**, select only the AMD GPU class you are validating.
 6. Select CPU, RAM, and storage for the image and workload you intend to test. A small matrix test does not establish
    production resource requirements.
-7. If the image's default process exits, add a long-running command such as `sleep infinity` only after confirming that
-   the command exists in the exact image. A command override replaces the image's configured entrypoint and command.
+7. If the image's default process exits, configure a keepalive command. For a PyTorch image with `python3`, enter
+   `python3` as the command, `-c` as the first argument, and `import time; time.sleep(2147483647)` as the second
+   argument. Do not include quotes around the arguments. See
+   [Specifying a command](/container-engine/how-to-guides/specifying-a-command).
 8. No Container Gateway is required for this terminal-based test.
 9. Deploy the group and wait for its instance to reach **Running**. If it repeatedly exits or reallocates, inspect
    [System Events](/container-engine/explanation/container-groups/system-events) before changing the ROCm stack.
 10. Open the running instance and select the **Terminal** tab. See
     [SSH and terminal access](/container-engine/explanation/container-groups/ssh-and-terminal).
 
-Do not copy local Docker host options such as `--device /dev/kfd` or `--device /dev/dri` into the container group.
-SaladCloud handles GPU allocation after you select the GPU class. The distinction is explained in
-[Local Docker Instructions Versus SaladCloud](/container-engine/reference/amd-gpus#local-docker-instructions-versus-saladcloud).
+SaladCloud handles the GPU device and runtime-library integration after you select the GPU class. Do not copy local WSL2
+Docker device or library-mount options into the container group. See
+[SaladCloud's WSL2 GPU Runtime](/container-engine/reference/amd-gpus#saladclouds-wsl2-gpu-runtime).
 
 ## 3. Verify PyTorch ROCm
 
-First, show whether the container configuration explicitly restricts GPU visibility:
+Confirm that the GPU device is present:
+
+```bash
+test -c /dev/dxg && echo "PASS: /dev/dxg present" || echo "FAIL: /dev/dxg missing"
+```
+
+SaladCloud AMD instances use the WSL2 GPU path, so stop and collect diagnostic information for Salad support if
+`/dev/dxg` is missing.
+
+Next, show whether the container configuration explicitly restricts GPU visibility:
 
 ```bash
 env | grep -E '^(ROCR_VISIBLE_DEVICES|HIP_VISIBLE_DEVICES|CUDA_VISIBLE_DEVICES)=' || true
@@ -101,7 +118,7 @@ env | grep -E '^(ROCR_VISIBLE_DEVICES|HIP_VISIBLE_DEVICES|CUDA_VISIBLE_DEVICES)=
 An empty result means that none of these variables is explicitly set. Unexpected values can hide devices from the
 application; compare them with the container group configuration before changing them.
 
-Then run a deterministic operation in the Salad terminal:
+Run the deterministic GPU test:
 
 ```bash
 python3 - <<'PY'
@@ -120,7 +137,11 @@ if not torch.cuda.is_available() or torch.cuda.device_count() < 1:
     raise SystemExit("PyTorch cannot access an AMD GPU")
 
 device = torch.device("cuda:0")
+properties = torch.cuda.get_device_properties(0)
+
 print("GPU:", torch.cuda.get_device_name(0))
+print("GPU memory bytes:", properties.total_memory)
+print("GPU memory GiB:", round(properties.total_memory / (1024**3), 2))
 
 a = torch.ones((1024, 1024), device=device)
 b = torch.ones((1024, 1024), device=device)
@@ -137,6 +158,7 @@ if actual != 1024.0:
 print("Result device:", c.device)
 print("Result shape:", tuple(c.shape))
 print("Result check:", actual)
+print("PASS: ROCm-enabled PyTorch completed the GPU operation")
 PY
 ```
 
@@ -149,20 +171,17 @@ check prevents a CUDA build on an NVIDIA GPU from passing this ROCm test. See
 The test passes when:
 
 - `ROCm/HIP` contains a version and `CUDA build` is normally `None`.
-- `GPU available` is `True`.
-- `GPU count` is at least `1`. Under the current Container Engine model, each container instance has one attached GPU,
-  so the expected count is `1`.
-- The reported GPU corresponds to the AMD class selected for the container group.
+- `GPU available` is `True` and `GPU count` is at least `1`.
+- The reported GPU matches the AMD class selected for the container group.
 - The result device is `cuda:0`, the shape is `(1024, 1024)`, and the result check is `1024.0`.
 
 This test allocates its inputs on the GPU, waits for asynchronous GPU work to finish, verifies the output device, and
 checks a known result. It is stronger than device enumeration, but it is not a substitute for running the real
 application.
 
-## Optional ROCm Diagnostics
+## Optional `rocminfo` Diagnostics
 
-The selected image might include `rocminfo` or AMD SMI. Use these read-only commands to record the detected architecture
-and device when they are available:
+When the image includes `rocminfo`, use it to identify the GPU's `gfx` target:
 
 ```bash
 if command -v rocminfo >/dev/null 2>&1; then
@@ -170,18 +189,14 @@ if command -v rocminfo >/dev/null 2>&1; then
 else
   echo "rocminfo is not installed in this image"
 fi
-
-if command -v amd-smi >/dev/null 2>&1; then
-  amd-smi version
-  amd-smi list
-else
-  echo "amd-smi is not installed in this image"
-fi
 ```
 
-These tools are supplied by the container image, not added automatically by GPU selection. A missing utility identifies
-an image-inventory issue; it does not by itself override a passing PyTorch GPU test. Add the tool to a diagnostic image
-when you need its output.
+Do not make AMD SMI success an acceptance requirement. SaladCloud's WSL2 environment does not expose the native Linux
+`amdgpu` kernel module expected by AMD SMI. Do not run a suggested `modprobe` command inside SaladCloud; use `rocminfo`
+and the PyTorch operation as the device checks.
+
+Diagnostic executables are supplied by the image, not added automatically by GPU selection. A missing utility identifies
+an image-inventory issue; it does not by itself override a passing PyTorch GPU test.
 
 ## 4. Validate the Real Workload
 
@@ -207,7 +222,8 @@ Save enough information to reproduce the result:
 | Test identity             | Date, operator, organization, project, and container group       |
 | Salad hardware            | GPU class name and ID                                            |
 | Immutable image identity  | Versioned image tag and resolved digest, when available          |
-| Reported stack            | ROCm/HIP, PyTorch, Python, application, and AMD SMI versions     |
+| Salad runtime             | `/dev/dxg`, container OS, glibc, and relevant library paths      |
+| Reported stack            | ROCm/HIP, PyTorch, Python, and application versions              |
 | Detected device           | PyTorch device name and `gfx` target, when `rocminfo` is present |
 | Container configuration   | CPU, RAM, storage, command, environment variables, and replicas  |
 | Application configuration | Model, precision, quantization, custom operators, and input size |
@@ -255,9 +271,8 @@ export CONTAINER_MEMORY_MB='<memory-in-mb>'
 export CONTAINER_STORAGE_BYTES='<storage-in-bytes>'
 ```
 
-The payload below uses `sleep infinity` to keep the diagnostic container available for terminal access. Confirm that
-`sleep` accepts `infinity` in the exact image, or replace the `command` array with a long-running command that you have
-tested in that image.
+The payload uses the Python keepalive command from the Portal workflow. Confirm that `python3` exists in the selected
+image before deploying it:
 
 ```bash
 jq -n \
@@ -278,7 +293,7 @@ jq -n \
         storage_amount: $storage,
         gpu_classes: [$gpu_class]
       },
-      command: ["sleep", "infinity"]
+      command: ["python3", "-c", "import time; time.sleep(2147483647)"]
     },
     autostart_policy: false,
     restart_policy: "always",
@@ -315,7 +330,20 @@ test, delete the group through the Portal or the
 ### The Instance Does Not Stay Running
 
 Review Container Logs and System Events. Check the selected GPU vendor, the image's default process or command override,
-and the configured CPU, RAM, and storage before changing ROCm or PyTorch versions.
+and the configured CPU, RAM, and storage before changing ROCm or PyTorch versions. Confirm that any keepalive command
+exists in the selected image.
+
+### PyTorch Fails to Import
+
+An import-time shared-library or glibc error can indicate that the image's operating-system ABI is incompatible with the
+SaladCloud runtime libraries. Choose a compatible base image or rebuild the application image; do not replace the
+SaladCloud runtime libraries from inside the container.
+
+### `/dev/dxg` Is Missing
+
+SaladCloud AMD instances use the WSL2 GPU path. If `/dev/dxg` is missing, collect the class name and ID, image tag,
+Container Logs, and System Events for Salad support. Do not try to create or mount the device from inside the container,
+and do not substitute native Linux ROCm device nodes.
 
 ### `ROCm/HIP` Is Empty
 
@@ -330,10 +358,15 @@ Confirm that the instance received the intended AMD class. Inspect `ROCR_VISIBLE
 collect the class name and ID, image tag and digest, PyTorch output, Container Logs, and System Events for Salad
 support.
 
-### `rocminfo` or `amd-smi` Is Missing
+### `rocminfo` Is Missing
 
-The utility is not included in the image or is not on `PATH`. Add the required user-space package while building a
-diagnostic image. Do not try to install or replace the host GPU driver from the container.
+The utility is not included in the image or is not on `PATH`. Add the required user-space diagnostic package while
+building the image. SaladCloud manages the GPU runtime; do not try to replace it from the container.
+
+### AMD SMI Reports That `amdgpu` Is Not Loaded
+
+SaladCloud's environment does not expose the native Linux `amdgpu` kernel module expected by AMD SMI. Do not run
+`sudo modprobe amdgpu` inside the container. Use `rocminfo` and the PyTorch GPU operation as the acceptance checks.
 
 ### `hipErrorNoBinaryForGPU`
 

--- a/dictionaries/salad-cloud.txt
+++ b/dictionaries/salad-cloud.txt
@@ -3,6 +3,7 @@
 adamw
 AKIAIOSFODNN
 alwayson
+amdgpu
 amqps
 amzn
 APAC
@@ -128,6 +129,7 @@ Kuzco
 LAVIS
 Letzeburgesch
 lib-dynload
+libdrm
 libgl1
 libgl1-mesa-dev
 libsm6
@@ -228,6 +230,9 @@ risczero
 Roboflow
 rocm
 rocminfo
+rocprofv
+ROCR
+rocr
 routable
 rpsj
 rqns
@@ -309,6 +314,7 @@ vaeapp
 Valencian
 vCPU
 VCPU
+vcpu
 vcpus
 vimeo
 vkapp

--- a/dictionaries/salad-cloud.txt
+++ b/dictionaries/salad-cloud.txt
@@ -96,6 +96,7 @@ healthz
 heun
 heygordian
 httpie
+hwdsl
 imds
 IMDS
 imdssdk
@@ -117,6 +118,8 @@ Kaspa
 KAWPOW
 kimi
 konieshadow
+kokoro
+Kokoro
 Kryptex
 kubeconfig
 kubelet
@@ -173,9 +176,11 @@ ntomp
 numpy
 nvcc
 NVCC
+nccl
 NCCL
 nvcr
 nvidia
+nvml
 nvtop
 ollama
 Ollama
@@ -211,13 +216,18 @@ Pytube
 quantizations
 Quickstart
 qwen
+randn
 rclone
 Rclone
 reauthentication
+rerank
+reranker
 REVAI
 risc
 risczero
 Roboflow
+rocm
+rocminfo
 routable
 rpsj
 rqns
@@ -265,6 +275,7 @@ supervisord
 svix
 saoudrizwan
 tedlium
+tensorrt
 threadpoolctl
 timeframe
 tlsv
@@ -289,6 +300,7 @@ Unsloth
 UNSLOTH
 unspec
 UNSPEC
+unvalidated
 upscaler
 upscalers
 uvicorn

--- a/docs.json
+++ b/docs.json
@@ -141,6 +141,7 @@
                 "group": "Machine Learning",
                 "pages": [
                   "container-engine/tutorials/machine-learning/pytorch-rtx5090",
+                  "container-engine/tutorials/machine-learning/pytorch-amd-rocm",
                   "container-engine/tutorials/machine-learning/run-triton-server",
                   "container-engine/tutorials/machine-learning/run-cog",
                   "container-engine/tutorials/machine-learning/jupyterlab",
@@ -311,6 +312,7 @@
             "group": "Reference",
             "pages": [
               "container-engine/reference/api",
+              "container-engine/reference/amd-gpus",
               {
                 "group": "Recipes",
                 "pages": [
@@ -319,6 +321,7 @@
                   "container-engine/reference/recipes/comfyui",
                   "container-engine/reference/recipes/gromacs-kelpie",
                   "container-engine/reference/recipes/gromacs-srcg",
+                  "container-engine/reference/recipes/kokoro-tts-api",
                   "container-engine/reference/recipes/kuzco",
                   "container-engine/reference/recipes/llama-cpp",
                   "container-engine/reference/recipes/gemma-4-31b-it-llama-cpp",
@@ -337,6 +340,7 @@
                   "container-engine/reference/recipes/sam3",
                   "container-engine/reference/recipes/sogni-fast-worker",
                   "container-engine/reference/recipes/tei-bge-m3",
+                  "container-engine/reference/recipes/tei-bge-reranker-v2-m3",
                   "container-engine/reference/recipes/tgi",
                   "container-engine/reference/recipes/ubuntu",
                   "container-engine/reference/recipes/unsloth-finetune",


### PR DESCRIPTION
This pull request updates documentation across several files to clarify SaladCloud's support for both NVIDIA and AMD GPUs, provides guidance on selecting compatible images, and expands troubleshooting advice for GPU compatibility. The changes also update last-modified dates for accuracy and improve technical explanations for GPU runtime errors and long-running job management.

**GPU vendor and image compatibility updates:**

* Updated all references to GPU hardware to clarify that SaladCloud supports selected NVIDIA and AMD GPU classes, not just NVIDIA RTX/GTX, and added instructions to use the [List GPU Classes API] for current inventory. [[1]](diffhunk://#diff-b200e51b0213266f192d4d94769392faced6943178d46bd10556eb8584548cacL36-R40) [[2]](diffhunk://#diff-b927001a9e9929a5af7e529426621a65da4e627322ef8e25c77a1224d137eca7L33-R39) [[3]](diffhunk://#diff-b927001a9e9929a5af7e529426621a65da4e627322ef8e25c77a1224d137eca7L53-R62)
* Expanded troubleshooting guidance to cover both CUDA (NVIDIA) and ROCm/HIP (AMD) runtime errors, including new sections on how to check GPU compatibility, common mistakes (e.g., using a CUDA image with AMD GPUs), and suggested diagnostic commands. [[1]](diffhunk://#diff-619436f4c7f1437f864c89c23c00471cdd3ee9f0c487eb7a8fd3dc3785051c20L79-R79) [[2]](diffhunk://#diff-619436f4c7f1437f864c89c23c00471cdd3ee9f0c487eb7a8fd3dc3785051c20L91-R93) [[3]](diffhunk://#diff-619436f4c7f1437f864c89c23c00471cdd3ee9f0c487eb7a8fd3dc3785051c20R105-R119)

**Technical clarifications and best practices:**

* Improved explanations of liveness probes to include checking for unrecoverable GPU runtime errors for both NVIDIA (CUDA) and AMD (ROCm/HIP) workloads.
* Clarified that multiprocessing for GPU inference creates a separate GPU runtime context (not just CUDA) and loads its own model into VRAM, making the language vendor-agnostic.

**Documentation maintenance:**

* Updated "Last Updated" timestamps in all modified files to July 13, 2026, reflecting the latest revision. [[1]](diffhunk://#diff-b200e51b0213266f192d4d94769392faced6943178d46bd10556eb8584548cacL7-R7) [[2]](diffhunk://#diff-b927001a9e9929a5af7e529426621a65da4e627322ef8e25c77a1224d137eca7L6-R6) [[3]](diffhunk://#diff-5997158844e52e86d57246ae97615a62446e2ed0303d7b283eb0f9306c8f3035L5-R13) [[4]](diffhunk://#diff-16fda990d71c54153f95f0c7028e355a2ac7e6e8205335347b0c8b8874affdb4L7-R7) [[5]](diffhunk://#diff-619436f4c7f1437f864c89c23c00471cdd3ee9f0c487eb7a8fd3dc3785051c20L7-R7)