### PR TITLE
Pricing update for aws and lambda

### DIFF
--- a/container-engine/explanation/container-groups/deployment-lifecycle.mdx
+++ b/container-engine/explanation/container-groups/deployment-lifecycle.mdx
@@ -61,7 +61,7 @@ desired replica count for your deployment.
 
 # Commonly asked questions
 
-### My instance is stuck at 99% creating, help!
+### My instance is stuck at 99 percent creating, help!
 
 Downloading and Creating instance statuses are estimated based on average download and setup times. If your instance is
 taking longer than expected to get set up, it will appear to hang at 99% creating. In this case, it is likely

--- a/container-engine/how-to-guides/migration/migrate-from-aws-batch.mdx
+++ b/container-engine/how-to-guides/migration/migrate-from-aws-batch.mdx
@@ -6,7 +6,7 @@ description:
   savings while maintaining job orchestration capabilities.'
 ---
 
-_Last Updated: November 6, 2025_
+_Last Updated: July 21, 2026_
 
 # Overview
 
@@ -52,11 +52,11 @@ GPU-intensive workloads. SaladCloud offers a compelling alternative that address
 
 **Cost Advantages:**
 
-- **90% Lower Compute Costs**: GPU + CPU + RAM combined cost a fraction of EC2 instances
-  - RTX 4090 setup: \$0.30/hr at high priority vs P3.2xlarge: \$3.06/hr
+- **Lower Compute Costs**: GPU + CPU + RAM combined cost a fraction of comparable EC2 GPU instances
+  - RTX 4090 setup: \$0.364/hr at high priority vs AWS g5.xlarge: \$1.006/hr
 - **Transparent Component Pricing**:
-  - **GPU Containers:**GPU hourly rate
-  - **CPU-only Containers:** - \$0.004/vCPU/hour + \$0.001/GB RAM/hour
+  - **GPU Containers:** GPU hourly rate
+  - **CPU-only Containers:** \$0.004/vCPU/hour + \$0.001/GB RAM/hour
 - **Per-Second Billing**: Hourly rates tracked per second for running containers
 - **No Hidden Costs**: No charges for VPC endpoints, NAT gateways, or data transfer between AZs
 
@@ -72,7 +72,7 @@ GPU-intensive workloads. SaladCloud offers a compelling alternative that address
 - Long-running batch jobs where startup time is less critical
 - GPU-intensive workloads (ML training, rendering, simulations)
 - Cost-sensitive batch processing
-- Non-time-critical workloads (batch priority adds 40-50% savings on top of base 90% savings)
+- Non-time-critical workloads (Lowest/Batch priority can add 40-50% GPU-rate savings compared with High priority)
 - Globally distributed data processing
 - Development and testing environments
 
@@ -808,44 +808,45 @@ async def process_job(job: dict):
 
 ## Cost Optimization Strategies
 
-### 1. Use Batch Priority for Non-Time-Sensitive Workloads
+### 1. Use Lowest/Batch Priority for Non-Time-Sensitive Workloads
 
 SaladCloud offers four priority tiers, with each tier offering additional savings on top of our already competitive base
-pricing (which is typically 80-90% less than AWS). For batch processing that isn't time-critical, the "batch" priority
-tier offers the deepest discounts:
+pricing. For batch processing that isn't time-critical, the "Lowest" priority tier, formerly called "Batch," offers the
+deepest discounts:
 
-| Priority   | Use Case                  | Additional Savings vs Salad High Priority | Availability |
-| ---------- | ------------------------- | ----------------------------------------- | ------------ |
-| **High**   | Production, time-critical | Baseline (already ~90% less than AWS)     | Highest      |
-| **Medium** | Standard workloads        | ~15-20% additional savings                | Very Good    |
-| **Low**    | Flexible deadlines        | ~25-35% additional savings                | Good         |
-| **Batch**  | Non-urgent processing     | **~40-50% additional savings**            | Variable     |
+| Priority   | Use Case                  | Additional GPU-Rate Savings vs Salad High Priority | Availability |
+| ---------- | ------------------------- | --------------------------------------------------- | ------------ |
+| **High**   | Production, time-critical | Baseline                                            | Highest      |
+| **Medium** | Standard workloads        | ~15-20% additional savings                          | Very Good    |
+| **Low**    | Flexible deadlines        | ~25-35% additional savings                          | Good         |
+| **Lowest** | Non-urgent processing     | **~40-50% additional savings**                      | Variable     |
 
-Example pricing for comparable GPU workload (24 GB VRAM, 8 vCPU, 32 GB RAM):
+Example pricing for GPU batch workloads. AWS examples use Linux On-Demand prices in US East (N. Virginia); the SaladCloud
+example requests 24 GB VRAM, 8 vCPU, and 32 GB RAM.
 
 **AWS P4d.24xlarge (8x A100 40GB):**
 
-- Total: ~\$32.77/hour
-- Per GPU: ~\$4.10/hour
+- Total: ~\$21.96/hour
+- Per GPU: ~\$2.75/hour
 - Includes: 96 vCPUs, 1152 GB RAM (massive overkill for most batch jobs)
 
-**AWS P3.2xlarge (1x V100 16GB):**
+**AWS g5.xlarge (1x A10G 24GB):**
 
-- Total: ~\$3.06/hour
-- Per GPU: \$3.06/hour
-- Includes: 8 vCPUs, 61 GB RAM
+- Total: ~\$1.006/hour
+- Per GPU: ~\$1.006/hour
+- Includes: 4 vCPUs, 16 GB RAM
 
 **SaladCloud RTX 4090 (24 GB):**
 
-- High Priority: \$0.30/hour GPU + \$0.032/hour (8 vCPU) + \$0.032/hour (32 GB RAM) = **\$0.364/hour total** (88% less
-  than P3.2xlarge)
+- High Priority: \$0.30/hour GPU + \$0.032/hour (8 vCPU) + \$0.032/hour (32 GB RAM) = **\$0.364/hour total** (64% less
+  than g5.xlarge)
 - Medium: \$0.26 + \$0.032 + \$0.032 = **\$0.324/hour**
 - Low: \$0.22 + \$0.032 + \$0.032 = **\$0.284/hour**
-- **Batch: \$0.18 + \$0.032 + \$0.032 = \$0.244/hour** (92% less than P3.2xlarge!)
+- **Lowest/Batch: \$0.18 + \$0.032 + \$0.032 = \$0.244/hour** (76% less than g5.xlarge and 91% less than P4d per GPU)
 
 ```python
-# Configure container group with batch priority for maximum savings
-# This gives you an additional 40% off SaladCloud's already low prices
+# Configure container group with Lowest/Batch priority for maximum savings
+# This gives you an additional 40% off the high-priority GPU rate
 container_group = sdk.container_groups.create_container_group(
     organization_name="your-org",
     project_name="your-project",

--- a/container-engine/how-to-guides/migration/migrate-from-aws-batch.mdx
+++ b/container-engine/how-to-guides/migration/migrate-from-aws-batch.mdx
@@ -815,14 +815,14 @@ pricing. For batch processing that isn't time-critical, the "Lowest" priority ti
 deepest discounts:
 
 | Priority   | Use Case                  | Additional GPU-Rate Savings vs Salad High Priority | Availability |
-| ---------- | ------------------------- | --------------------------------------------------- | ------------ |
-| **High**   | Production, time-critical | Baseline                                            | Highest      |
-| **Medium** | Standard workloads        | ~15-20% additional savings                          | Very Good    |
-| **Low**    | Flexible deadlines        | ~25-35% additional savings                          | Good         |
-| **Lowest** | Non-urgent processing     | **~40-50% additional savings**                      | Variable     |
+| ---------- | ------------------------- | -------------------------------------------------- | ------------ |
+| **High**   | Production, time-critical | Baseline                                           | Highest      |
+| **Medium** | Standard workloads        | ~15-20% additional savings                         | Very Good    |
+| **Low**    | Flexible deadlines        | ~25-35% additional savings                         | Good         |
+| **Lowest** | Non-urgent processing     | **~40-50% additional savings**                     | Variable     |
 
-Example pricing for GPU batch workloads. AWS examples use Linux On-Demand prices in US East (N. Virginia); the SaladCloud
-example requests 24 GB VRAM, 8 vCPU, and 32 GB RAM.
+Example pricing for GPU batch workloads. AWS examples use Linux On-Demand prices in US East (N. Virginia); the
+SaladCloud example requests 24 GB VRAM, 8 vCPU, and 32 GB RAM.
 
 **AWS P4d.24xlarge (8x A100 40GB):**
 

--- a/container-engine/how-to-guides/migration/migrate-from-lambda-cloud.mdx
+++ b/container-engine/how-to-guides/migration/migrate-from-lambda-cloud.mdx
@@ -6,7 +6,7 @@ description:
   up to 90% while keeping your existing code and workflows.'
 ---
 
-_Last Updated: February 20, 2026_
+_Last Updated: July 21, 2026_
 
 # Overview
 
@@ -21,7 +21,8 @@ deploy it as a **container group**. Your code stays the same, only the runtime e
 ## What Stays Exactly the Same
 
 - Your application code, models, and algorithms remain unchanged
-- Same Python libraries, PyTorch/TensorFlow frameworks, and CUDA operations
+- The same Python libraries, PyTorch/TensorFlow frameworks, and CUDA operations when you select compatible NVIDIA GPU
+  classes and a compatible CUDA image
 - Identical API patterns, data processing workflows, and model inference logic
 - Same Docker containers if you're already containerized
 
@@ -97,24 +98,25 @@ fit.
 
 # Cost Comparison
 
-SaladCloud pricing shown below is for the **Batch** priority tier (lowest cost). Higher priority tiers cost more but
-provide greater availability guarantees.
+SaladCloud pricing shown below uses current **Batch** priority rates for the listed GPU instance configuration. Higher
+priority tiers cost more but provide greater availability guarantees.
 
 | Use Case                       | Lambda GPU              | Lambda $/hr | SaladCloud GPU   | SaladCloud $/hr | Savings |
 | ------------------------------ | ----------------------- | ----------- | ---------------- | --------------- | ------- |
-| LLM Inference (7–13B)          | A10 (24 GB)             | ~$0.86      | RTX 4090 (24 GB) | ~$0.16          | ~81%    |
-| Image Generation (SD/FLUX)     | A10 (24 GB)             | ~$0.86      | RTX 3090 (24 GB) | ~$0.09          | ~90%    |
-| Transcription (Whisper)        | Quadro RTX 6000 (24 GB) | ~$0.58      | RTX 3090 (24 GB) | ~$0.09          | ~84%    |
-| Batch Embeddings               | A100 PCIe (40 GB)       | ~$1.48      | RTX 4090 (24 GB) | ~$0.16          | ~89%    |
-| LLM Inference (34B–70B quant.) | A6000 (48 GB)           | ~$0.92      | RTX 5090 (32 GB) | ~$0.25          | ~73%    |
+| LLM Inference (7–13B)          | A10 (24 GB)             | ~$1.29      | RTX 4090 (24 GB) | ~$0.204         | ~84%    |
+| Image Generation (SD/FLUX)     | A10 (24 GB)             | ~$1.29      | RTX 3090 (24 GB) | ~$0.124         | ~90%    |
+| Transcription (Whisper)        | Quadro RTX 6000 (24 GB) | ~$0.69      | RTX 3090 (24 GB) | ~$0.124         | ~82%    |
+| Batch Embeddings               | A100 PCIe (40 GB)       | ~$1.99      | RTX 4090 (24 GB) | ~$0.204         | ~90%    |
+| LLM Inference (34B–70B quant.) | A6000 (48 GB)           | ~$1.09      | RTX 5090 (32 GB) | ~$0.294         | ~73%    |
 
 **Example: 100 GPU-hours of inference per day**
 
-- **Lambda (A10):** 100 × $0.86/hr = ~$2,580/month
-- **SaladCloud (RTX 4090, batch):** 100 × $0.16/hr = ~$480/month
+- **Lambda (A10):** 100 × $1.29/hr = ~$3,870/month
+- **SaladCloud (RTX 4090, batch):** 100 × $0.204/hr = ~$612/month
 
 <Note>
-  Prices are approximate and subject to change. Check [salad.com/pricing](https://salad.com/pricing) and
+  Prices are approximate, exclude applicable taxes, and are subject to change. Available instance types can vary by
+  region and account. Check [salad.com/pricing](https://salad.com/pricing) and
   [lambda.ai/pricing](https://lambda.ai/pricing) for current rates.
 </Note>
 

--- a/container-engine/how-to-guides/troubleshooting.mdx
+++ b/container-engine/how-to-guides/troubleshooting.mdx
@@ -117,7 +117,7 @@ Inside a running replica, use diagnostics supplied by the image:
 - **AMD:** If the image includes them, run `rocminfo` and `amd-smi list`, and inspect the application logs for ROCm,
   HIP, or `gfx` compatibility errors.
 
-## My Container Group Is Stuck Downloading / Stuck at Downloading 99%
+## My Container Group Is Stuck Downloading / Stuck at Downloading 99 Percent
 
 First, check the instances are not looping between downloading and allocating as above. However, if a single node has
 been in the "Downloading" state for a long time (more than 2 minutes per GB of image size), you may have landed on a

--- a/transcription/reference/accuracy-benchmarks.mdx
+++ b/transcription/reference/accuracy-benchmarks.mdx
@@ -11,7 +11,7 @@ datasets. Below is a breakdown of results by language and dataset.
 
 ---
 
-### Languages with Accuracy ≥ 90%
+### Languages with Accuracy 90 Percent or Higher
 
 - English
 - Portuguese
@@ -23,14 +23,14 @@ datasets. Below is a breakdown of results by language and dataset.
 
 ---
 
-### Languages with Accuracy between 80%–89%
+### Languages with Accuracy between 80 and 89 Percent
 
 - Hindi
 - Hebrew
 
 ---
 
-### Languages with Accuracy < 80%
+### Languages with Accuracy below 80 Percent
 
 - Urdu
 - Kazakh


### PR DESCRIPTION
This pull request updates the AWS Batch and Lambda Cloud migration guides to reflect current pricing, GPU instance types, and priority tier names. It clarifies cost comparisons, corrects example calculations, and improves the accuracy of technical descriptions.

**Pricing and Instance Updates:**

- Updated all cost comparison tables and examples in both guides to use current GPU instance types (e.g., AWS g5.xlarge, Lambda A10) and current SaladCloud rates, with revised savings percentages and dollar amounts. [[1]](diffhunk://#diff-4811669916eb0e9042b4b92182bfbeebc1bafa0bf31cb12bd9adcb8d6e7995e6L55-R59) [[2]](diffhunk://#diff-4811669916eb0e9042b4b92182bfbeebc1bafa0bf31cb12bd9adcb8d6e7995e6L811-R849) [[3]](diffhunk://#diff-0b4e9bf24061663ca7e9b5326dbc68ee18fd693ed7f675c45f30d576e9a38976L100-R119)
- Clarified that all prices are approximate, may vary by region/account, and exclude taxes.

**Priority Tier Naming and Descriptions:**

- Renamed "Batch" priority to "Lowest/Batch" throughout the AWS Batch guide, and clarified the savings and availability of each priority tier. [[1]](diffhunk://#diff-4811669916eb0e9042b4b92182bfbeebc1bafa0bf31cb12bd9adcb8d6e7995e6L75-R75) [[2]](diffhunk://#diff-4811669916eb0e9042b4b92182bfbeebc1bafa0bf31cb12bd9adcb8d6e7995e6L811-R849)
- Updated cost optimization strategy section to reflect the new priority tier names and their impact on pricing.

**Technical Clarifications:**

- Clarified that using compatible NVIDIA GPU classes and CUDA images is necessary for seamless migration of Python libraries and frameworks from Lambda Cloud.

**Documentation Maintenance:**

- Updated the "Last Updated" dates in both guides to July 21, 2026. [[1]](diffhunk://#diff-4811669916eb0e9042b4b92182bfbeebc1bafa0bf31cb12bd9adcb8d6e7995e6L9-R9) [[2]](diffhunk://#diff-0b4e9bf24061663ca7e9b5326dbc68ee18fd693ed7f675c45f30d576e9a38976L9-R9)